### PR TITLE
Fix cache configuration

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,5 +1,5 @@
 {
-    "Enable": ["deadcode", "golint", "vet", "gotype", "gocyclo", "maligned", "errcheck", "megacheck", "misspell", "unused", "staticcheck"],
+    "Enable": ["deadcode", "golint", "vet", "gotype", "gocyclo", "maligned", "errcheck", "misspell", "staticcheck"],
     "Exclude": ["test"],
     "Format": "[{{.Severity}}]: {{.Path}}: {{.Line}}:{{if .Col}}{{.Col}}{{end}}: {{.Message}} ({{.Linter}})",
     "Deadline": "120s",

--- a/pkg/sbproxy/reconcile/reconcile_settings.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings.go
@@ -23,8 +23,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const cacheDefaultExpirationTime = 2 * time.Hour
-
 // Settings type represents the sbproxy settings
 type Settings struct {
 	URL      string `mapstructure:"url"`
@@ -42,7 +40,7 @@ func DefaultSettings() *Settings {
 		Username:        "",
 		Password:        "",
 		VisibilityCache: true,
-		CacheExpiration: cacheDefaultExpirationTime,
+		CacheExpiration: 2 * time.Hour,
 	}
 }
 

--- a/pkg/sbproxy/reconcile/reconcile_settings.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings.go
@@ -23,6 +23,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const cacheDefaultExpirationTime = 2 * time.Hour
+
 // Settings type represents the sbproxy settings
 type Settings struct {
 	URL      string `mapstructure:"url"`
@@ -40,7 +42,7 @@ func DefaultSettings() *Settings {
 		Username:        "",
 		Password:        "",
 		VisibilityCache: true,
-		CacheExpiration: time.Hour,
+		CacheExpiration: cacheDefaultExpirationTime,
 	}
 }
 

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -40,9 +40,7 @@ const (
 	// Path for the Proxy OSB API
 	Path = APIPrefix + "/{" + BrokerPathParam + "}"
 
-	cacheDefaultExpirationTime = 1 * time.Hour
-
-	cacheCleanupInterval = 2 * time.Minute
+	cacheCleanupInterval = 1 * time.Minute
 )
 
 // SMProxyBuilder type is an extension point that allows adding additional filters, plugins and
@@ -130,7 +128,7 @@ func New(ctx context.Context, cancel context.CancelFunc, env env.Environment, pl
 		panic(err)
 	}
 
-	c := cache.New(cacheDefaultExpirationTime, cacheCleanupInterval)
+	c := cache.New(cfg.Reconcile.CacheExpiration, cacheCleanupInterval)
 	regJob := reconcile.NewTask(ctx, cfg.Reconcile, &group, platformClient, smClient, cfg.Reconcile.URL+APIPrefix, c)
 
 	resyncSchedule := "@every " + cfg.Sm.ResyncPeriod.String()


### PR DESCRIPTION
Currently the platform cache has default settings set and cannot be configured.
This fix propagates the configuration to the cache.
Default cache expiration set to 2 hours.