### PR TITLE
Use broker name instead of id

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,7 @@
 
 [[projects]]
   branch = "notifications"
-  digest = "1:56e18675c34a2f49317c276056b07d10f1c20bad94d835174a344bc39786d368"
+  digest = "1:b2b0471f0787ef4726baed4ecad1a9f01049cc3e1c3287b9ffa0a7fdc46820eb"
   name = "github.com/Peripli/service-manager"
   packages = [
     "api",
@@ -40,7 +40,7 @@
     "test/testutil",
   ]
   pruneopts = "NT"
-  revision = "e8442809d1728747be8f302801fca089d5aebabb"
+  revision = "8ca1238dca788770b5022d6ec479f357e0641c9c"
 
 [[projects]]
   digest = "1:f780d408067189c4c42b53f7bb24ebf8fd2a1e4510b813ed6e79dd6563e38cc5"

--- a/pkg/sbproxy/notifications/handlers/broker_handler.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler.go
@@ -204,7 +204,7 @@ func (bnh *BrokerResourceNotificationsHandler) brokerProxyPath(broker *types.Ser
 }
 
 func (bnh *BrokerResourceNotificationsHandler) brokerProxyName(broker *types.ServiceBroker) string {
-	return bnh.ProxyPrefix + broker.GetID()
+	return bnh.ProxyPrefix + broker.Name
 }
 
 func shouldBeProxified(brokerFromPlatform *platform.ServiceBroker, brokerFromSM *types.ServiceBroker) bool {

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Broker Handler", func() {
 
 				expectedUpdateBrokerRequest = &platform.UpdateServiceBrokerRequest{
 					GUID:      smBrokerID,
-					Name:      brokerHandler.ProxyPrefix + smBrokerID,
+					Name:      brokerHandler.ProxyPrefix + brokerName,
 					BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
 				}
 
@@ -265,7 +265,7 @@ var _ = Describe("Broker Handler", func() {
 					}, nil)
 
 					expectedCreateBrokerRequest = &platform.CreateServiceBrokerRequest{
-						Name:      brokerHandler.ProxyPrefix + smBrokerID,
+						Name:      brokerHandler.ProxyPrefix + brokerName,
 						BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
 					}
 
@@ -433,7 +433,7 @@ var _ = Describe("Broker Handler", func() {
 				BeforeEach(func() {
 					expectedUpdateBrokerRequest = &platform.ServiceBroker{
 						GUID:      smBrokerID,
-						Name:      brokerHandler.ProxyPrefix + smBrokerID,
+						Name:      brokerHandler.ProxyPrefix + brokerName,
 						BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
 					}
 
@@ -570,7 +570,7 @@ var _ = Describe("Broker Handler", func() {
 				BeforeEach(func() {
 					expectedDeleteBrokerRequest = &platform.DeleteServiceBrokerRequest{
 						GUID: smBrokerID,
-						Name: brokerHandler.ProxyPrefix + smBrokerID,
+						Name: brokerHandler.ProxyPrefix + brokerName,
 					}
 
 					fakeBrokerClient.DeleteBrokerReturns(nil)

--- a/pkg/sbproxy/notifications/handlers/visibilities_handler.go
+++ b/pkg/sbproxy/notifications/handlers/visibilities_handler.go
@@ -95,7 +95,7 @@ func (vnh *VisibilityResourceNotificationsHandler) OnCreate(ctx context.Context,
 
 	v := visPayload.New
 
-	platformBrokerName := vnh.ProxyPrefix + v.Additional.BrokerID
+	platformBrokerName := vnh.ProxyPrefix + v.Additional.BrokerName
 	if err := vnh.VisibilityClient.EnableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
 		BrokerName:    platformBrokerName,
 		CatalogPlanID: v.Additional.ServicePlan.CatalogID,
@@ -127,7 +127,7 @@ func (vnh *VisibilityResourceNotificationsHandler) OnUpdate(ctx context.Context,
 	oldVisibilityPayload := visibilityPayload.Old
 	newVisibilityPayload := visibilityPayload.New
 
-	platformBrokerName := vnh.ProxyPrefix + oldVisibilityPayload.Additional.BrokerID
+	platformBrokerName := vnh.ProxyPrefix + oldVisibilityPayload.Additional.BrokerName
 
 	labelsToAdd, labelsToRemove := LabelChangesToLabels(visibilityPayload.LabelChanges)
 
@@ -190,7 +190,7 @@ func (vnh *VisibilityResourceNotificationsHandler) OnDelete(ctx context.Context,
 
 	v := visibilityPayload.Old
 
-	platformBrokerName := vnh.ProxyPrefix + v.Additional.BrokerID
+	platformBrokerName := vnh.ProxyPrefix + v.Additional.BrokerName
 	if err := vnh.VisibilityClient.DisableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
 		BrokerName:    platformBrokerName,
 		CatalogPlanID: v.Additional.ServicePlan.CatalogID,


### PR DESCRIPTION
Use sm broker name instead of sm broker id when registering a broker at the platform