### PR TITLE
Remove platform visibility cache

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -376,14 +376,6 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:808cdddf087fb64baeae67b8dfaee2069034d9704923a3cb8bd96a995421a625"
-  name = "github.com/patrickmn/go-cache"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
-  version = "v2.1.0"
-
-[[projects]]
   digest = "1:93131d8002d7025da13582877c32d1fc302486775a1b06f62241741006428c5e"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
@@ -609,7 +601,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "cbcb750295291b33242907a04be40e80801d0cfc"
+  revision = "22d7a77e9e5f409e934ed268692e56707cd169e5"
 
 [[projects]]
   branch = "master"
@@ -625,7 +617,7 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "a4d6f7feada510cc50e69a37b484cb0fdc6b7876"
+  revision = "3ec19112720433827bbce8be9342797f5a6aaaf9"
 
 [[projects]]
   branch = "master"
@@ -636,15 +628,15 @@
     "internal",
   ]
   pruneopts = "UT"
-  revision = "9f3314589c9a9136388751d9adae6b0ed400978a"
+  revision = "950ef44c6e079baf075030377d90bf0c7e4b7b7a"
 
 [[projects]]
   branch = "master"
-  digest = "1:4fc43e824f7e546353de724c00507b1d9c0bab56344b10c2330a97f166a0fba7"
+  digest = "1:3851a6d548ec5a808e396408f03a30b8d05ef4426db7ad8688f639b2d88b47bd"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "a5b02f93d862f065920dd6a40dddc66b60d0dec4"
+  revision = "61b9204099cb1bebc803c9ffb9b2d3acd9d457d9"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"
@@ -696,8 +688,8 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "54a98f90d1c46b7731eb8fb305d2a321c30ef610"
-  version = "v1.5.0"
+  revision = "4c25cacc810c02874000e4f7071286a8e96b2515"
+  version = "v1.6.0"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -766,7 +758,6 @@
     "github.com/onsi/ginkgo/extensions/table",
     "github.com/onsi/gomega",
     "github.com/onsi/gomega/ghttp",
-    "github.com/patrickmn/go-cache",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cast",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,10 +51,6 @@
   source = "https://github.com/fsnotify/fsnotify.git"
 
 [[constraint]]
-  name = "github.com/patrickmn/go-cache"
-  version = "2.1.0"
-
-[[constraint]]
   name = "github.com/gorilla/websocket"
   version = "1.4.0"
 

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -35,7 +35,7 @@ type brokerKey struct {
 
 // reconcileBrokers attempts to reconcile the current brokers state in the platform (existingBrokers)
 // to match the desired broker state coming from the Service Manager (payloadBrokers).
-func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers []platform.ServiceBroker, payloadBrokers []platform.ServiceBroker) {
+func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers, payloadBrokers []platform.ServiceBroker) {
 	brokerKeyMap := indexBrokersByKey(existingBrokers)
 	proxyBrokerIDMap := indexProxyBrokersByID(existingBrokers, r.proxyPath)
 

--- a/pkg/sbproxy/reconcile/reconcile_brokers_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers_test.go
@@ -19,11 +19,7 @@ package reconcile_test
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
-
-	"github.com/patrickmn/go-cache"
 
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
 	"github.com/Peripli/service-broker-proxy/pkg/platform/platformfakes"
@@ -92,8 +88,6 @@ var _ = Describe("Reconcile brokers", func() {
 		fakePlatformClient.CatalogFetcherReturns(fakePlatformCatalogFetcher)
 		fakePlatformClient.VisibilityReturns(fakePlatformVisibilitiesClient)
 
-		visibilityCache := cache.New(5*time.Minute, 10*time.Minute)
-
 		platformClient := struct {
 			*platformfakes.FakeCatalogFetcher
 			*platformfakes.FakeClient
@@ -103,7 +97,7 @@ var _ = Describe("Reconcile brokers", func() {
 		}
 
 		reconciler = &reconcile.Reconciler{
-			Resyncer: reconcile.NewResyncer(reconcile.DefaultSettings(), platformClient, fakeSMClient, fakeAppHost, visibilityCache),
+			Resyncer: reconcile.NewResyncer(reconcile.DefaultSettings(), platformClient, fakeSMClient, fakeAppHost),
 		}
 
 		smbroker1 = sm.Broker{

--- a/pkg/sbproxy/reconcile/reconcile_settings.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings.go
@@ -18,8 +18,6 @@ package reconcile
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/pkg/errors"
 )
 
@@ -33,20 +31,15 @@ type Settings struct {
 	Password string `mapstructure:"password"`
 
 	BrokerPrefix string `mapstructure:"broker_prefix"`
-
-	VisibilityCache bool          `mapstructure:"visibility_cache"`
-	CacheExpiration time.Duration `mapstructure:"cache_expiration"`
 }
 
 // DefaultSettings creates default proxy settings
 func DefaultSettings() *Settings {
 	return &Settings{
-		URL:             "",
-		Username:        "",
-		Password:        "",
-		BrokerPrefix:    DefaultProxyBrokerPrefix,
-		VisibilityCache: true,
-		CacheExpiration: 2 * time.Hour,
+		URL:          "",
+		Username:     "",
+		Password:     "",
+		BrokerPrefix: DefaultProxyBrokerPrefix,
 	}
 }
 
@@ -60,11 +53,6 @@ func (c *Settings) Validate() error {
 	}
 	if len(c.Password) == 0 {
 		return errors.New("validate settings: missing password")
-	}
-	if c.VisibilityCache {
-		if time.Minute > c.CacheExpiration {
-			return errors.New("validate settings: if cache is enabled, cache_expiration should be at least 1 minute")
-		}
 	}
 	return nil
 }

--- a/pkg/sbproxy/reconcile/reconcile_settings_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings_test.go
@@ -17,8 +17,6 @@
 package reconcile_test
 
 import (
-	"time"
-
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 
 	. "github.com/onsi/ginkgo"
@@ -63,14 +61,6 @@ var _ = Describe("Reconcile", func() {
 				It("returns an error", func() {
 					settings := validSettings()
 					settings.Password = ""
-					Expect(settings.Validate()).Should(HaveOccurred())
-				})
-			})
-
-			Context("when CacheExpiration is less then 1 minute", func() {
-				It("returns an error", func() {
-					settings := validSettings()
-					settings.CacheExpiration = time.Second
 					Expect(settings.Validate()).Should(HaveOccurred())
 				})
 			})

--- a/pkg/sbproxy/reconcile/reconcile_visibilities.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities.go
@@ -18,104 +18,26 @@ package reconcile
 
 import (
 	"context"
-	"strings"
-	"sync"
-	"time"
-
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/types"
-)
-
-const (
-	platformVisibilityCacheKey = "platform_visibilities"
-	smPlansCacheKey            = "sm_plans"
+	"strings"
+	"sync"
 )
 
 // reconcileVisibilities handles the reconciliation of the service visibilities
 func (r *resyncJob) reconcileVisibilities(ctx context.Context, smVisibilities []*platform.Visibility, smBrokers []platform.ServiceBroker, plans map[brokerPlanKey]*types.ServicePlan) {
-	var platformVisibilities []*platform.Visibility
-	visibilityCacheUsed := false
-	if r.options.VisibilityCache && r.areSMPlansSame(ctx, plans) {
-		log.C(ctx).Infof("Actual SM plans and cached SM plans are same. Attempting to pick up cached platform visibilities...")
-		platformVisibilities = r.getPlatformVisibilitiesFromCache(ctx)
-		visibilityCacheUsed = true
-	}
-
-	if platformVisibilities == nil {
-		log.C(ctx).Infof("Actual SM plans and cached SM plans are different. Invalidating cached platform visibilities and calling platform API to fetch actual platform visibilities...")
-		var err error
-		platformVisibilities, err = r.getPlatformVisibilitiesByBrokersFromPlatform(ctx, smBrokers)
-		if err != nil {
-			log.C(ctx).WithError(err).Error("An error occurred while loading visibilities from platform")
-			return
-		}
+	log.C(ctx).Infof("Calling platform API to fetch actual platform visibilities")
+	platformVisibilities, err := r.getPlatformVisibilitiesByBrokersFromPlatform(ctx, smBrokers)
+	if err != nil {
+		log.C(ctx).WithError(err).Error("An error occurred while loading visibilities from platform")
+		return
 	}
 
 	errorOccured := r.reconcileServiceVisibilities(ctx, platformVisibilities, smVisibilities)
 	if errorOccured {
 		log.C(ctx).Error("Could not reconcile visibilities")
 	}
-
-	if r.options.VisibilityCache {
-		if errorOccured {
-			r.cache.Delete(platformVisibilityCacheKey)
-			r.cache.Delete(smPlansCacheKey)
-		} else {
-			r.updateVisibilityCache(ctx, visibilityCacheUsed, plans, smVisibilities)
-		}
-	}
-}
-
-func (r *resyncJob) updateVisibilityCache(ctx context.Context, visibilityCacheUsed bool, plansMap map[brokerPlanKey]*types.ServicePlan, visibilities []*platform.Visibility) {
-	log.C(ctx).Infof("Updating cache with the %d newly fetched SM plans as cached-SM-plans and expiration duration %s", len(plansMap), r.options.CacheExpiration)
-	r.cache.Set(smPlansCacheKey, plansMap, r.options.CacheExpiration)
-	visibilitiesExpiration := r.options.CacheExpiration
-	if visibilityCacheUsed {
-		_, expiration, found := r.cache.GetWithExpiration(platformVisibilityCacheKey)
-		if found {
-			visibilitiesExpiration = time.Until(expiration)
-		}
-	}
-
-	log.C(ctx).Infof("Updating cache with the %d newly fetched SM visibilities as cached-platform-visibilities and expiration duration %s", len(visibilities), visibilitiesExpiration)
-	r.cache.Set(platformVisibilityCacheKey, visibilities, visibilitiesExpiration)
-}
-
-// areSMPlansSame checks if there are new or deleted plans in SM.
-// Returns true if there are no new or deleted plans, false otherwise
-func (r *resyncJob) areSMPlansSame(ctx context.Context, plansMap map[brokerPlanKey]*types.ServicePlan) bool {
-	cachedPlans, isPresent := r.cache.Get(smPlansCacheKey)
-	if !isPresent {
-		return false
-	}
-	cachedPlansMap, ok := cachedPlans.(map[brokerPlanKey]*types.ServicePlan)
-	if !ok {
-		log.C(ctx).Error("Service Manager plans cache is in invalid state! Clearing...")
-		r.cache.Delete(smPlansCacheKey)
-		return false
-	}
-
-	for key := range plansMap {
-		if cachedPlansMap[key] == nil {
-			return false
-		}
-	}
-	return true
-}
-
-func (r *resyncJob) getPlatformVisibilitiesFromCache(ctx context.Context) []*platform.Visibility {
-	platformVisibilities, found := r.cache.Get(platformVisibilityCacheKey)
-	if !found {
-		return nil
-	}
-	if result, ok := platformVisibilities.([]*platform.Visibility); ok {
-		log.C(ctx).Infof("resyncJob fetched %d platform visibilities from cache", len(result))
-		return result
-	}
-	log.C(ctx).Error("Platform visibilities cache is in invalid state! Clearing...")
-	r.cache.Delete(platformVisibilityCacheKey)
-	return nil
 }
 
 func (r *resyncJob) getPlatformVisibilitiesByBrokersFromPlatform(ctx context.Context, brokers []platform.ServiceBroker) ([]*platform.Visibility, error) {

--- a/pkg/sbproxy/reconcile/resyncer.go
+++ b/pkg/sbproxy/reconcile/resyncer.go
@@ -3,8 +3,6 @@ package reconcile
 import (
 	"context"
 
-	"github.com/patrickmn/go-cache"
-
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
 	"github.com/Peripli/service-broker-proxy/pkg/sm"
 
@@ -16,13 +14,12 @@ import (
 
 // NewResyncer returns a resyncer that reconciles the state of the proxy brokers and visibilities
 // in the platform to match the desired state provided by the Service Manager.
-func NewResyncer(settings *Settings, platformClient platform.Client, smClient sm.Client, proxyPath string, cache *cache.Cache) Resyncer {
+func NewResyncer(settings *Settings, platformClient platform.Client, smClient sm.Client, proxyPath string) Resyncer {
 	return &resyncJob{
 		options:        settings,
 		platformClient: platformClient,
 		smClient:       smClient,
 		proxyPath:      proxyPath,
-		cache:          cache,
 	}
 }
 
@@ -31,7 +28,6 @@ type resyncJob struct {
 	platformClient platform.Client
 	smClient       sm.Client
 	proxyPath      string
-	cache          *cache.Cache
 }
 
 // Resync reconciles the state of the proxy brokers and visibilities at the platform

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/Peripli/service-manager/pkg/types"
 
-	"github.com/patrickmn/go-cache"
-
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/notifications/handlers"
 
 	"fmt"
@@ -60,8 +58,6 @@ const (
 
 	// Path for the Proxy OSB API
 	Path = APIPrefix + "/{" + BrokerPathParam + "}"
-
-	cacheCleanupInterval = 1 * time.Minute
 )
 
 // SMProxyBuilder type is an extension point that allows adding additional filters, plugins and
@@ -144,9 +140,8 @@ func New(ctx context.Context, cancel context.CancelFunc, env env.Environment, pl
 	if err != nil {
 		panic(err)
 	}
-	cache := cache.New(cfg.Reconcile.CacheExpiration, cacheCleanupInterval)
 	proxyPath := cfg.Reconcile.URL + APIPrefix
-	resyncer := reconcile.NewResyncer(cfg.Reconcile, platformClient, smClient, proxyPath, cache)
+	resyncer := reconcile.NewResyncer(cfg.Reconcile, platformClient, smClient, proxyPath)
 	consumer := &notifications.Consumer{
 		Handlers: map[types.ObjectType]notifications.ResourceNotificationHandler{
 			types.ServiceBrokerType: &handlers.BrokerResourceNotificationsHandler{


### PR DESCRIPTION
With the introduction of Notifications and the full-resync job being executed at longer periods, the platform visibility cache has little value.

Also, this would fix the bug where creating a visibility in a platform won't be deleted until the cache has expired. 