### PR TITLE
Issues with broker naming scheme in platforms

### DIFF
--- a/pkg/sbproxy/notifications/handlers/broker_handler.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler.go
@@ -153,19 +153,23 @@ func (bnh *BrokerResourceNotificationsHandler) OnUpdate(ctx context.Context, pay
 	brokerProxyNameAfter := bnh.brokerProxyName(brokerAfterUpdate.Resource)
 	brokerProxyPath := bnh.brokerProxyPath(brokerAfterUpdate.Resource)
 
-	log.C(ctx).Infof("Attempting to find platform broker with name %s in platform...", brokerProxyNameAfter)
-	existingBroker, err := bnh.BrokerClient.GetBrokerByName(ctx, brokerProxyNameAfter)
+	brokerToFind := brokerProxyNameAfter
+	if brokerProxyNameBefore != brokerProxyNameAfter {
+		brokerToFind = brokerProxyNameBefore
+	}
+	log.C(ctx).Infof("Attempting to find platform broker with name %s in platform...", brokerToFind)
+	existingBroker, err := bnh.BrokerClient.GetBrokerByName(ctx, brokerToFind)
 	if err != nil {
-		log.C(ctx).Errorf("Could not find broker with name %s in the platform: %s. No update will be attempted", brokerProxyNameAfter, err)
+		log.C(ctx).Errorf("Could not find broker with name %s in the platform: %s. No update will be attempted", brokerToFind, err)
 		return
 	} else if existingBroker == nil {
-		log.C(ctx).Errorf("Could not find broker with name %s in the platform. No update will be attempted", brokerProxyNameAfter)
+		log.C(ctx).Errorf("Could not find broker with name %s in the platform. No update will be attempted", brokerToFind)
 		return
 	}
 	log.C(ctx).Infof("Successfully found platform broker with name %s and URL %s.", existingBroker.Name, existingBroker.BrokerURL)
 
 	if existingBroker.BrokerURL != brokerProxyPath {
-		log.C(ctx).Errorf("Platform broker with name %s has an URL %s and is not proxified by SM. No update will be attempted", brokerProxyNameAfter, existingBroker.BrokerURL)
+		log.C(ctx).Errorf("Platform broker with name %s has an URL %s and is not proxified by SM. No update will be attempted", existingBroker.Name, existingBroker.BrokerURL)
 		return
 	}
 

--- a/pkg/sbproxy/notifications/handlers/broker_handler.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler.go
@@ -180,7 +180,7 @@ func (bnh *BrokerResourceNotificationsHandler) OnUpdate(ctx context.Context, pay
 		return
 	}
 
-	log.C(ctx).Infof("Refetching	catalog for broker with name %s...", brokerProxyNameAfter)
+	log.C(ctx).Infof("Refetching catalog for broker with name %s...", brokerProxyNameAfter)
 	fetchCatalogRequest := &platform.ServiceBroker{
 		GUID:      existingBroker.GUID,
 		Name:      brokerProxyNameAfter,

--- a/pkg/sbproxy/notifications/handlers/broker_handler.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/Peripli/service-manager-cli/pkg/errors"
+	"github.com/pkg/errors"
 
 	"github.com/Peripli/service-manager/storage/interceptors"
 
@@ -245,10 +245,10 @@ func (bnh *BrokerResourceNotificationsHandler) OnDelete(ctx context.Context, pay
 func (bnh *BrokerResourceNotificationsHandler) unmarshalPayload(operationType types.OperationType, payload json.RawMessage) (brokerPayload, error) {
 	result := brokerPayload{}
 	if err := json.Unmarshal(payload, &result); err != nil {
-		return brokerPayload{}, errors.New("error unmarshaling broker create notification payload", err)
+		return brokerPayload{}, errors.Wrap(err, "error unmarshaling broker create notification payload")
 	}
 	if err := result.Validate(operationType); err != nil {
-		return brokerPayload{}, errors.New("error validating broker payload", err)
+		return brokerPayload{}, errors.Wrap(err, "error validating broker payload")
 	}
 	return result, nil
 }

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -483,7 +483,7 @@ var _ = Describe("Broker Handler", func() {
 				fakeBrokerClient.UpdateBrokerReturns(nil, nil)
 			})
 
-			FIt("Should update the broker name in the platform", func() {
+			It("Should update the broker name in the platform", func() {
 				var updateRequest *platform.UpdateServiceBrokerRequest
 				fakeBrokerClient.UpdateBrokerStub = func(_ context.Context, request *platform.UpdateServiceBrokerRequest) (*platform.ServiceBroker, error) {
 					updateRequest = request

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -32,10 +32,6 @@ var _ = Describe("Broker Handler", func() {
 
 	var err error
 
-	brokerProxyName := func(brokerName, brokerID string) string {
-		return fmt.Sprintf("%s%s-%s", brokerHandler.ProxyPrefix, brokerName, brokerID)
-	}
-
 	BeforeEach(func() {
 		ctx = context.TODO()
 
@@ -225,7 +221,7 @@ var _ = Describe("Broker Handler", func() {
 
 				expectedUpdateBrokerRequest = &platform.UpdateServiceBrokerRequest{
 					GUID:      smBrokerID,
-					Name:      brokerProxyName(brokerName, smBrokerID),
+					Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 					BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
 				}
 
@@ -265,7 +261,7 @@ var _ = Describe("Broker Handler", func() {
 					fakeBrokerClient.GetBrokerByNameReturns(nil, nil)
 
 					expectedCreateBrokerRequest = &platform.CreateServiceBrokerRequest{
-						Name:      brokerProxyName(brokerName, smBrokerID),
+						Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 						BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
 					}
 
@@ -471,12 +467,12 @@ var _ = Describe("Broker Handler", func() {
 		}`, smBrokerID, oldBrokerName, brokerURL, catalog, smBrokerID, newBrokerName, brokerURL, catalog)
 
 				fakeBrokerClient.GetBrokerByNameStub = func(_ context.Context, name string) (*platform.ServiceBroker, error) {
-					if name != brokerProxyName(oldBrokerName, smBrokerID) {
+					if name != brokerProxyName(brokerHandler.ProxyPrefix, oldBrokerName, smBrokerID) {
 						return nil, fmt.Errorf("could not find broker with name %s", name)
 					}
 					return &platform.ServiceBroker{
 						GUID:      smBrokerID,
-						Name:      brokerProxyName(name, smBrokerID),
+						Name:      brokerProxyName(brokerHandler.ProxyPrefix, name, smBrokerID),
 						BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
 					}, nil
 				}
@@ -496,7 +492,7 @@ var _ = Describe("Broker Handler", func() {
 				brokerHandler.OnUpdate(ctx, json.RawMessage(brokerNotificationPayload))
 				Expect(updateRequest).To(Equal(&platform.UpdateServiceBrokerRequest{
 					GUID:      smBrokerID,
-					Name:      brokerProxyName(newBrokerName, smBrokerID),
+					Name:      brokerProxyName(brokerHandler.ProxyPrefix, newBrokerName, smBrokerID),
 					BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
 				}))
 			})
@@ -506,7 +502,7 @@ var _ = Describe("Broker Handler", func() {
 			BeforeEach(func() {
 				fakeBrokerClient.GetBrokerByNameReturns(&platform.ServiceBroker{
 					GUID:      smBrokerID,
-					Name:      brokerProxyName(smBrokerID, smBrokerID),
+					Name:      brokerProxyName(brokerHandler.ProxyPrefix, smBrokerID, smBrokerID),
 					BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
 				}, nil)
 
@@ -530,7 +526,7 @@ var _ = Describe("Broker Handler", func() {
 				BeforeEach(func() {
 					expectedUpdateBrokerRequest = &platform.ServiceBroker{
 						GUID:      smBrokerID,
-						Name:      brokerProxyName(brokerName, smBrokerID),
+						Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 						BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
 					}
 
@@ -667,7 +663,7 @@ var _ = Describe("Broker Handler", func() {
 				BeforeEach(func() {
 					expectedDeleteBrokerRequest = &platform.DeleteServiceBrokerRequest{
 						GUID: smBrokerID,
-						Name: brokerProxyName(brokerName, smBrokerID),
+						Name: brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 					}
 
 					fakeBrokerClient.DeleteBrokerReturns(nil)

--- a/pkg/sbproxy/notifications/handlers/handlers_suite_test.go
+++ b/pkg/sbproxy/notifications/handlers/handlers_suite_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Peripli/service-manager/test/testutil"
@@ -21,4 +22,8 @@ func VerifyErrorLogged(f func()) {
 	Expect(hook).ToNot(ContainSubstring("error"))
 	f()
 	Expect(hook).To(ContainSubstring("error"))
+}
+
+func brokerProxyName(prefix, brokerName, brokerID string) string {
+	return fmt.Sprintf("%s%s-%s", prefix, brokerName, brokerID)
 }

--- a/pkg/sbproxy/notifications/handlers/visibilities_handler.go
+++ b/pkg/sbproxy/notifications/handlers/visibilities_handler.go
@@ -95,7 +95,7 @@ func (vnh *VisibilityResourceNotificationsHandler) OnCreate(ctx context.Context,
 	}
 
 	v := visPayload.New
-	platformBrokerName := vnh.ProxyPrefix + v.Additional.BrokerName
+	platformBrokerName := vnh.brokerProxyName(v.Additional.BrokerName, v.Additional.BrokerID)
 
 	log.C(ctx).Infof("Attempting to enable access for plan with catalog ID %s for platform broker with name %s and labels %v...", v.Additional.ServicePlan.CatalogID, platformBrokerName, v.Resource.GetLabels())
 
@@ -133,7 +133,7 @@ func (vnh *VisibilityResourceNotificationsHandler) OnUpdate(ctx context.Context,
 	oldVisibilityPayload := visibilityPayload.Old
 	newVisibilityPayload := visibilityPayload.New
 
-	platformBrokerName := vnh.ProxyPrefix + oldVisibilityPayload.Additional.BrokerName
+	platformBrokerName := vnh.brokerProxyName(oldVisibilityPayload.Additional.BrokerName, oldVisibilityPayload.Additional.BrokerID)
 
 	labelsToAdd, labelsToRemove := LabelChangesToLabels(visibilityPayload.LabelChanges)
 
@@ -227,7 +227,7 @@ func (vnh *VisibilityResourceNotificationsHandler) OnDelete(ctx context.Context,
 	}
 
 	v := visibilityPayload.Old
-	platformBrokerName := vnh.ProxyPrefix + v.Additional.BrokerName
+	platformBrokerName := vnh.brokerProxyName(v.Additional.BrokerName, v.Additional.BrokerID)
 
 	log.C(ctx).Infof("Attempting to disable access for plan with catalog ID %s for platform broker with name %s and labels %v...", v.Additional.ServicePlan.CatalogID, platformBrokerName, v.Resource.GetLabels())
 
@@ -241,4 +241,8 @@ func (vnh *VisibilityResourceNotificationsHandler) OnDelete(ctx context.Context,
 	}
 	log.C(ctx).Infof("Successfully disabled access for plan with catalog ID %s for platform broker with name %s and labels %v...", v.Additional.ServicePlan.CatalogID, platformBrokerName, v.Resource.GetLabels())
 
+}
+
+func (vnh *VisibilityResourceNotificationsHandler) brokerProxyName(brokerName, brokerID string) string {
+	return fmt.Sprintf("%s%s-%s", vnh.ProxyPrefix, brokerName, brokerID)
 }

--- a/pkg/sbproxy/notifications/handlers/visibility_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/visibility_handler_test.go
@@ -57,10 +57,6 @@ var _ = Describe("Visibility Handler", func() {
 		return labelChanges
 	}
 
-	brokerProxyName := func(brokerName, brokerID string) string {
-		return fmt.Sprintf("%s%s-%s", visibilityHandler.ProxyPrefix, brokerName, brokerID)
-	}
-
 	BeforeEach(func() {
 		ctx = context.TODO()
 
@@ -261,7 +257,7 @@ var _ = Describe("Visibility Handler", func() {
 					fakeVisibilityClient.EnableAccessForPlanReturns(nil)
 
 					expectedRequest = &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+						BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 						CatalogPlanID: catalogPlanID,
 						Labels:        unmarshalLabels(labels),
 					}
@@ -454,7 +450,7 @@ var _ = Describe("Visibility Handler", func() {
 					labelsToAdd, labelsToRemove = handlers.LabelChangesToLabels(unmarshalLabelChanges(labelChanges))
 					expectedEnableAccessRequests = []*platform.ModifyPlanAccessRequest{
 						{
-							BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+							BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 							CatalogPlanID: catalogPlanID,
 							Labels:        labelsToAdd,
 						},
@@ -462,7 +458,7 @@ var _ = Describe("Visibility Handler", func() {
 
 					expectedDisableAccessRequests = []*platform.ModifyPlanAccessRequest{
 						{
-							BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+							BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 							CatalogPlanID: catalogPlanID,
 							Labels:        labelsToRemove,
 						},
@@ -490,14 +486,14 @@ var _ = Describe("Visibility Handler", func() {
 						Expect(err).ShouldNot(HaveOccurred())
 						expectedEnableAccessRequests = []*platform.ModifyPlanAccessRequest{
 							{
-								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+								BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 								CatalogPlanID: catalogPlanID,
 								Labels:        types.Labels{},
 							},
 						}
 						expectedDisableAccessRequests = []*platform.ModifyPlanAccessRequest{
 							{
-								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+								BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 								CatalogPlanID: catalogPlanID,
 								Labels:        types.Labels{},
 							},
@@ -535,12 +531,12 @@ var _ = Describe("Visibility Handler", func() {
 
 						expectedEnableAccessRequests = []*platform.ModifyPlanAccessRequest{
 							{
-								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+								BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 								CatalogPlanID: anotherCatalogPlanID,
 								Labels:        unmarshalLabels(labels),
 							},
 							{
-								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+								BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 								CatalogPlanID: anotherCatalogPlanID,
 								Labels:        labelsToAdd,
 							},
@@ -548,12 +544,12 @@ var _ = Describe("Visibility Handler", func() {
 
 						expectedDisableAccessRequests = []*platform.ModifyPlanAccessRequest{
 							{
-								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+								BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 								CatalogPlanID: catalogPlanID,
 								Labels:        unmarshalLabels(labels),
 							},
 							{
-								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+								BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 								CatalogPlanID: anotherCatalogPlanID,
 								Labels:        labelsToRemove,
 							},
@@ -647,7 +643,7 @@ var _ = Describe("Visibility Handler", func() {
 					fakeVisibilityClient.DisableAccessForPlanReturns(nil)
 
 					expectedRequest = &platform.ModifyPlanAccessRequest{
-						BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
+						BrokerName:    brokerProxyName(visibilityHandler.ProxyPrefix, smBrokerName, smBrokerID),
 						CatalogPlanID: catalogPlanID,
 						Labels:        unmarshalLabels(labels),
 					}

--- a/pkg/sbproxy/notifications/handlers/visibility_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/visibility_handler_test.go
@@ -57,6 +57,10 @@ var _ = Describe("Visibility Handler", func() {
 		return labelChanges
 	}
 
+	brokerProxyName := func(brokerName, brokerID string) string {
+		return fmt.Sprintf("%s%s-%s", visibilityHandler.ProxyPrefix, brokerName, brokerID)
+	}
+
 	BeforeEach(func() {
 		ctx = context.TODO()
 
@@ -257,7 +261,7 @@ var _ = Describe("Visibility Handler", func() {
 					fakeVisibilityClient.EnableAccessForPlanReturns(nil)
 
 					expectedRequest = &platform.ModifyPlanAccessRequest{
-						BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+						BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 						CatalogPlanID: catalogPlanID,
 						Labels:        unmarshalLabels(labels),
 					}
@@ -450,7 +454,7 @@ var _ = Describe("Visibility Handler", func() {
 					labelsToAdd, labelsToRemove = handlers.LabelChangesToLabels(unmarshalLabelChanges(labelChanges))
 					expectedEnableAccessRequests = []*platform.ModifyPlanAccessRequest{
 						{
-							BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+							BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 							CatalogPlanID: catalogPlanID,
 							Labels:        labelsToAdd,
 						},
@@ -458,7 +462,7 @@ var _ = Describe("Visibility Handler", func() {
 
 					expectedDisableAccessRequests = []*platform.ModifyPlanAccessRequest{
 						{
-							BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+							BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 							CatalogPlanID: catalogPlanID,
 							Labels:        labelsToRemove,
 						},
@@ -486,14 +490,14 @@ var _ = Describe("Visibility Handler", func() {
 						Expect(err).ShouldNot(HaveOccurred())
 						expectedEnableAccessRequests = []*platform.ModifyPlanAccessRequest{
 							{
-								BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 								CatalogPlanID: catalogPlanID,
 								Labels:        types.Labels{},
 							},
 						}
 						expectedDisableAccessRequests = []*platform.ModifyPlanAccessRequest{
 							{
-								BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 								CatalogPlanID: catalogPlanID,
 								Labels:        types.Labels{},
 							},
@@ -531,12 +535,12 @@ var _ = Describe("Visibility Handler", func() {
 
 						expectedEnableAccessRequests = []*platform.ModifyPlanAccessRequest{
 							{
-								BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 								CatalogPlanID: anotherCatalogPlanID,
 								Labels:        unmarshalLabels(labels),
 							},
 							{
-								BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 								CatalogPlanID: anotherCatalogPlanID,
 								Labels:        labelsToAdd,
 							},
@@ -544,12 +548,12 @@ var _ = Describe("Visibility Handler", func() {
 
 						expectedDisableAccessRequests = []*platform.ModifyPlanAccessRequest{
 							{
-								BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 								CatalogPlanID: catalogPlanID,
 								Labels:        unmarshalLabels(labels),
 							},
 							{
-								BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+								BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 								CatalogPlanID: anotherCatalogPlanID,
 								Labels:        labelsToRemove,
 							},
@@ -643,7 +647,7 @@ var _ = Describe("Visibility Handler", func() {
 					fakeVisibilityClient.DisableAccessForPlanReturns(nil)
 
 					expectedRequest = &platform.ModifyPlanAccessRequest{
-						BrokerName:    visibilityHandler.ProxyPrefix + smBrokerName,
+						BrokerName:    brokerProxyName(smBrokerName, smBrokerID),
 						CatalogPlanID: catalogPlanID,
 						Labels:        unmarshalLabels(labels),
 					}

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -51,7 +51,7 @@ func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers []plat
 		proxifiedBrokerName := r.options.BrokerPrefix + payloadBroker.Name
 		brokerWithProxifiedName, exists := existingBrokersByName[proxifiedBrokerName]
 		if exists && brokerWithProxifiedName.BrokerURL != r.proxyPath+"/"+payloadBroker.GUID { // broker is not created by SM, but is with an SM naming scheme
-			log.C(ctx).Info("Broker with name %s is already registered in the platform but with a different URL. Deleting it and creating a SM representation", proxifiedBrokerName)
+			log.C(ctx).Infof("Broker with name %s is already registered in the platform but with a different URL. Deleting it and creating a SM representation", proxifiedBrokerName)
 			r.deleteBrokerRegistration(ctx, brokerWithProxifiedName)
 			r.createBrokerRegistration(ctx, &payloadBroker)
 			continue

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -53,7 +53,11 @@ func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers []plat
 		if exists && brokerWithProxifiedName.BrokerURL != r.proxyPath+"/"+payloadBroker.GUID { // broker is not created by SM, but is with an SM naming scheme
 			log.C(ctx).Infof("Broker with name %s is already registered in the platform but with a different URL. Deleting it and creating a SM representation", proxifiedBrokerName)
 			r.deleteBrokerRegistration(ctx, brokerWithProxifiedName)
-			r.createBrokerRegistration(ctx, &payloadBroker)
+			if existingBroker != nil {
+				r.updateBrokerRegistration(ctx, existingBroker.GUID, &payloadBroker)
+			} else {
+				r.createBrokerRegistration(ctx, &payloadBroker)
+			}
 			continue
 		}
 

--- a/pkg/sbproxy/reconcile/reconcile_brokers_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers_test.go
@@ -77,10 +77,6 @@ var _ = Describe("Reconcile brokers", func() {
 		fakePlatformBrokerClient.UpdateBrokerReturns(&platformBrokerProxy, nil)
 	}
 
-	brokerProxyName := func(brokerName, brokerID string) string {
-		return fmt.Sprintf("%s%s-%s", reconcile.DefaultProxyBrokerPrefix, brokerName, brokerID)
-	}
-
 	BeforeEach(func() {
 		fakeSMClient = &smfakes.FakeClient{}
 		fakePlatformClient := &platformfakes.FakeClient{}

--- a/pkg/sbproxy/reconcile/reconcile_suite_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_suite_test.go
@@ -17,7 +17,10 @@
 package reconcile_test
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,4 +29,8 @@ import (
 func TestReconcile(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Reconcile Suite")
+}
+
+func brokerProxyName(brokerName, brokerID string) string {
+	return fmt.Sprintf("%s%s-%s", reconcile.DefaultProxyBrokerPrefix, brokerName, brokerID)
 }

--- a/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
@@ -18,6 +18,8 @@ package reconcile_test
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
 	"github.com/Peripli/service-broker-proxy/pkg/platform/platformfakes"
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
@@ -155,6 +157,10 @@ var _ = Describe("Reconcile visibilities", func() {
 		}, nil)
 	}
 
+	brokerProxyName := func(brokerName, brokerID string) string {
+		return fmt.Sprintf("%s%s-%s", reconcile.DefaultProxyBrokerPrefix, brokerName, brokerID)
+	}
+
 	BeforeEach(func() {
 		fakeSMClient = &smfakes.FakeClient{}
 		fakePlatformClient = &platformfakes.FakeClient{}
@@ -266,6 +272,7 @@ var _ = Describe("Reconcile visibilities", func() {
 
 		smbroker1 = sm.Broker{
 			ID:        "smBrokerID1",
+			Name:      "smBroker1",
 			BrokerURL: "https://smBroker1.com",
 			ServiceOfferings: []types.ServiceOffering{
 				smService1,
@@ -275,6 +282,7 @@ var _ = Describe("Reconcile visibilities", func() {
 
 		smbroker2 = sm.Broker{
 			ID:        "smBrokerID2",
+			Name:      "smBroker2",
 			BrokerURL: "https://smBroker2.com",
 			ServiceOfferings: []types.ServiceOffering{
 				smService3,
@@ -283,13 +291,13 @@ var _ = Describe("Reconcile visibilities", func() {
 
 		platformbroker1 = platform.ServiceBroker{
 			GUID:      "platformBrokerID1",
-			Name:      reconcile.DefaultProxyBrokerPrefix + "smBroker1",
+			Name:      brokerProxyName(smbroker1.Name, smbroker1.ID),
 			BrokerURL: fakeAppHost + "/" + smbroker1.ID,
 		}
 
 		platformbroker2 = platform.ServiceBroker{
 			GUID:      "platformBrokerID2",
-			Name:      reconcile.DefaultProxyBrokerPrefix + "smBroker2",
+			Name:      brokerProxyName(smbroker2.Name, smbroker2.ID),
 			BrokerURL: fakeAppHost + "/" + smbroker2.ID,
 		}
 
@@ -353,12 +361,12 @@ var _ = Describe("Reconcile visibilities", func() {
 				return expectations{
 					enablePlanVisibilityCalledFor: []*platform.Visibility{
 						{
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{"key": "value0"},
 						},
 						{
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{"key": "value1"},
 						},
@@ -374,12 +382,12 @@ var _ = Describe("Reconcile visibilities", func() {
 					{
 						CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 						Labels:             map[string]string{"key": "value0"},
-						PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+						PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 					},
 					{
 						CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 						Labels:             map[string]string{"key": "value1"},
-						PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+						PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 					},
 				}, nil
 			},
@@ -411,12 +419,12 @@ var _ = Describe("Reconcile visibilities", func() {
 					{
 						CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 						Labels:             map[string]string{"key": "value2"},
-						PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+						PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 					},
 					{
 						CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 						Labels:             map[string]string{"key": "value3"},
-						PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+						PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 					},
 				}, nil
 			},
@@ -440,24 +448,24 @@ var _ = Describe("Reconcile visibilities", func() {
 						{
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{"key": "value0"},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 						{
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{"key": "value1"},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 					},
 					disablePlanVisibilityCalledFor: []*platform.Visibility{
 						{
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{"key": "value2"},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 						{
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{"key": "value3"},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 					},
 				}
@@ -500,12 +508,12 @@ var _ = Describe("Reconcile visibilities", func() {
 						{
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{"key": "value0"},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 						{
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[1].CatalogID,
 							Labels:             map[string]string{"key": "value1"},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 					},
 				}
@@ -521,12 +529,12 @@ var _ = Describe("Reconcile visibilities", func() {
 					{
 						CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 						Labels:             map[string]string{"key": "value0"},
-						PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+						PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 					},
 					{
 						CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[1].CatalogID,
 						Labels:             map[string]string{"key": "value1"},
-						PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+						PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 					},
 				}, nil
 			},
@@ -540,12 +548,12 @@ var _ = Describe("Reconcile visibilities", func() {
 						{
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{"key": "value0"},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 						{
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[1].CatalogID,
 							Labels:             map[string]string{"key": "value1"},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 					},
 				}
@@ -603,7 +611,7 @@ var _ = Describe("Reconcile visibilities", func() {
 							Public:             true,
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 					},
 				}
@@ -616,7 +624,7 @@ var _ = Describe("Reconcile visibilities", func() {
 					{
 						Public:             true,
 						CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[1].CatalogID,
-						PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+						PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 					},
 				}, nil
 			},
@@ -635,7 +643,7 @@ var _ = Describe("Reconcile visibilities", func() {
 							Public:             true,
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[0].CatalogID,
 							Labels:             map[string]string{},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 					},
 					disablePlanVisibilityCalledFor: []*platform.Visibility{
@@ -643,7 +651,7 @@ var _ = Describe("Reconcile visibilities", func() {
 							Public:             true,
 							CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[1].CatalogID,
 							Labels:             map[string]string{},
-							PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+							PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 						},
 					},
 				}
@@ -656,7 +664,7 @@ var _ = Describe("Reconcile visibilities", func() {
 					{
 						Public:             true,
 						CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[1].CatalogID,
-						PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+						PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 					},
 				}, nil
 			},
@@ -680,7 +688,7 @@ var _ = Describe("Reconcile visibilities", func() {
 					{
 						Public:             true,
 						CatalogPlanID:      smbroker1.ServiceOfferings[0].Plans[1].CatalogID,
-						PlatformBrokerName: reconcile.DefaultProxyBrokerPrefix + smbroker1.Name,
+						PlatformBrokerName: brokerProxyName(smbroker1.Name, smbroker1.ID),
 					},
 				}, nil
 			},
@@ -694,6 +702,9 @@ var _ = Describe("Reconcile visibilities", func() {
 		}),
 
 		Entry("When visibilities from platform cannot be fetched - no reconcilation is done", testCase{
+			stubs: func() {
+
+			},
 			platformVisibilities: func() ([]*platform.Visibility, error) {
 				return nil, errors.New("Expected")
 			},

--- a/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
@@ -18,7 +18,6 @@ package reconcile_test
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
 	"github.com/Peripli/service-broker-proxy/pkg/platform/platformfakes"
@@ -155,10 +154,6 @@ var _ = Describe("Reconcile visibilities", func() {
 			platformbroker2,
 			platformbrokerNonProxy,
 		}, nil)
-	}
-
-	brokerProxyName := func(brokerName, brokerID string) string {
-		return fmt.Sprintf("%s%s-%s", reconcile.DefaultProxyBrokerPrefix, brokerName, brokerID)
 	}
 
 	BeforeEach(func() {


### PR DESCRIPTION
# Create Case 1
Register a broker in SM with name that would conflict with an already registered broker in the platform, because it tries to update an existing broker

## Platform Has
`sm-my-broker` - Directly registered in the platform(NOT via SM)
`my-broker`- Directly registered in the platform

## Service Manager Action
Register `my-broker`

## Problem
* Notifications:
SM -> SBProxy —> OnCreate —> update `my-broker` to `sm-my-broker` —> conflict 409 name

* Resync:
knownToSM = exists broker with url ending with the broker ID
knownToPlatform = exists broker with same URL and Name as the one in SM
SM -> SBProxy -> existing brokers is empty —> update broker registration of `my-broker` to `sm-my-broker` -> conflict 409 name

# Create Case 2
Register a broker in SM with name that would conflict with an already registered broker in the platform
## Platform Has
`sm-my-broker` - Directly registered in the platform 

## Service Manager Action 
Register `my-broker`

## Problem
* Notifications:
SM -> SBProxy —> OnCreate —> create new broker with name `sm-my-broker` —> conflict 409 name

* Resync:
Create new broker with name `sm-my-broker` -> conflict 409 name

# Create Case 3
## Platform has
`sm-my-broker` - proxified broker (registration in SM is `my-broker`
## Service Manager has
Broker registration with name`my-broker` 

## Platform action
Admin renames `sm-my-broker` to `sm-test`
## Service Manager action
Register a broker with name `test`

## Problem
* Notification
	* OnCreate checks if broker with name `test` exists in the platform to proxy it
	* As it doesn’t exist, this is a new broker and will try to create it
	* Fails with 409 conflict name

## Create Case 4
## Platform has
`sm-my-broker` - proxified broker (registration in SM is `my-broker`
## Service Manager has
Broker registration with name`my-broker` 

## Platform action
Admin renames `sm-my-broker` to `test`
## Service Manager action
Register a broker with name `test`

## Problem
* Notification
	* OnCreate checks if broker with name `test` exists in the platform to proxy it
	* As it does, it tries to update the broker registration
	* This will change the original broker which was `my-broker` to the `test` broker and `my-broker` will no longer be visible in the platform
* Resync is almost OK
	* existing broker is nil, because no broker with such guid exists in the platform
	* knownToPlatform is false, because no broker with both this URL and name exists in the platform
	* knownToSM is false
	* It will try to create a broker with name `sm-test` in the platform
	* Now there will be `sm-test` which is the new broker from SM, and `test` which is the old `my-broker` just renamed


# Update Case 1
Rename a broker to a name that would conflict with the name of an already registered broker in the platform
## Platform Has
`sm-my-broker` Proxified (registration is via SM)
`sm-test` Directly registered in the platform

## Service Manager
Has broker “my-broker”
Update `my-broker` - rename to `test`

## Problem
* Notification:
1. Get broker with name `sm-test` -> err = nil  & existing broker is found
2. Existing broker URL is not sm-proxy URL  -> stop 
* Resync:
knownToSM is true, because the ID is the one of `sm-my-broker`.
knownToPlatform is false, because the combination of name `test` and URL (the URL of the `my-broker` broker) does not match to a broker
Then only a catalog refetch will be triggered, which in CF triggers update broker which will change the catalog of the `sm-test` broker
SM->SBProxy -> OnUpdate changed name from `my-broker` to `test` should rename `sm-my-broker` to `sm-test`
