### PR TITLE
Fix Broker Name

### DIFF
--- a/pkg/sbproxy/reconcile/reconcile_visibilities.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities.go
@@ -58,7 +58,7 @@ func (r *resyncJob) getPlatformVisibilitiesByBrokersFromPlatform(ctx context.Con
 func (r *resyncJob) brokerNames(brokers []platform.ServiceBroker) []string {
 	names := make([]string, 0, len(brokers))
 	for _, broker := range brokers {
-		names = append(names, r.options.BrokerPrefix+broker.Name)
+		names = append(names, r.brokerProxyName(&broker))
 	}
 	return names
 }


### PR DESCRIPTION
https://github.com/Peripli/service-broker-proxy/pull/75 fixed an issue with conflicting broker names by appending the broker id to the proxy broker registration. 

However, the broker ID was not added everywhere and therefore when visibilities resync was happening, proxy always found 0 visibilities in platform and tried to create all SM visibilities.

This PR adds the broker id to the missed place so that proxy can properly fetch visibilities from platform for broker names and not try to create everything everytime