### PR TITLE
Register proxy broker URLs to point to SM instead of Proxy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -251,8 +251,8 @@
     "zlib",
   ]
   pruneopts = "UT"
-  revision = "8756f2777357367e8b792ec60331ce0d40fb925e"
-  version = "v1.6.2"
+  revision = "05d6922103c7275c684bd5df6608b25577b10521"
+  version = "v1.7.0"
 
 [[projects]]
   digest = "1:923c4d7194b42e054b2eb8a6c62824ac55e23ececc1c7e48d4da69c971c55954"
@@ -582,7 +582,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "f99c8df09eb5bff426315721bfa5f16a99cad32c"
+  revision = "5c40567a22f818bd14a1ea7245dad9f8ef0691aa"
 
 [[projects]]
   branch = "master"
@@ -598,7 +598,7 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "60506f45cf65977eb3a9c6e30f995f54a721c271"
+  revision = "d28f0bde5980168871434b95cfc858db9f2a7a99"
 
 [[projects]]
   branch = "master"
@@ -613,11 +613,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8f5108406bc43c7669b0d67d282e40d05c9f268615fcaf8c1f0f76965aa3f09f"
+  digest = "1:010311506e3917b54487c35a4277e2709678a40c1587d82492c40b78b6a0a01d"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "4c4f7f33c9ed00de01c4c741d2177abfcfe19307"
+  revision = "d442b75600c5d6484576502b3c53a55c54311be9"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"
@@ -669,8 +669,8 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "4c25cacc810c02874000e4f7071286a8e96b2515"
-  version = "v1.6.0"
+  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
+  version = "v1.6.1"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -243,7 +243,7 @@
   revision = "38398a30ed8516ffda617a04c822de09df8a3ec5"
 
 [[projects]]
-  digest = "1:589fb1a525a9596f15cf90064ad57cfad5de59b3579e91f272f470ab49051647"
+  digest = "1:823dc0f8e4cdad8d91e6aba4cdd985a035596a8aa02e9d2abf1bec347894c41f"
   name = "github.com/klauspost/compress"
   packages = [
     "flate",
@@ -251,8 +251,8 @@
     "zlib",
   ]
   pruneopts = "UT"
-  revision = "05d6922103c7275c684bd5df6608b25577b10521"
-  version = "v1.7.0"
+  revision = "7a873649b01a9669308e8d58b6bcbbccc0b06b5d"
+  version = "v1.7.1"
 
 [[projects]]
   digest = "1:923c4d7194b42e054b2eb8a6c62824ac55e23ececc1c7e48d4da69c971c55954"
@@ -582,7 +582,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "5c40567a22f818bd14a1ea7245dad9f8ef0691aa"
+  revision = "57b3e21c3d5606066a87e63cfe07ec6b9f0db000"
 
 [[projects]]
   branch = "master"
@@ -613,11 +613,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:010311506e3917b54487c35a4277e2709678a40c1587d82492c40b78b6a0a01d"
+  digest = "1:249fd56fb36a223aee164e2dc35e3b3a1b92dd3873dfb60216280b9fb9d4a784"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "d442b75600c5d6484576502b3c53a55c54311be9"
+  revision = "15dcb6c0061f497a3f66e3ea034b629c6dd4d99e"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"

--- a/pkg/sbproxy/notifications/handlers/broker_handler.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler.go
@@ -73,7 +73,7 @@ type BrokerResourceNotificationsHandler struct {
 	CatalogFetcher platform.CatalogFetcher
 
 	ProxyPrefix string
-	ProxyPath   string
+	SMPath      string
 }
 
 // OnCreate creates brokers from the specified notification payload by invoking the proper platform clients
@@ -254,7 +254,7 @@ func (bnh *BrokerResourceNotificationsHandler) unmarshalPayload(operationType ty
 }
 
 func (bnh *BrokerResourceNotificationsHandler) brokerProxyPath(broker *types.ServiceBroker) string {
-	return bnh.ProxyPath + "/" + broker.GetID()
+	return bnh.SMPath + "/" + broker.GetID()
 }
 
 func (bnh *BrokerResourceNotificationsHandler) brokerProxyName(broker *types.ServiceBroker) string {

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Broker Handler", func() {
 			BrokerClient:   fakeBrokerClient,
 			CatalogFetcher: fakeCatalogFetcher,
 			ProxyPrefix:    "proxyPrefix",
-			ProxyPath:      "proxyPath",
+			SMPath:         "proxyPath",
 		}
 	})
 
@@ -222,7 +222,7 @@ var _ = Describe("Broker Handler", func() {
 				expectedUpdateBrokerRequest = &platform.UpdateServiceBrokerRequest{
 					GUID:      smBrokerID,
 					Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
-					BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
+					BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
 				}
 
 				fakeBrokerClient.UpdateBrokerReturns(nil, fmt.Errorf("error"))
@@ -262,7 +262,7 @@ var _ = Describe("Broker Handler", func() {
 
 					expectedCreateBrokerRequest = &platform.CreateServiceBrokerRequest{
 						Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
-						BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
+						BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
 					}
 
 					fakeBrokerClient.CreateBrokerReturns(nil, nil)
@@ -473,7 +473,7 @@ var _ = Describe("Broker Handler", func() {
 					return &platform.ServiceBroker{
 						GUID:      smBrokerID,
 						Name:      brokerProxyName(brokerHandler.ProxyPrefix, name, smBrokerID),
-						BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
+						BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
 					}, nil
 				}
 				fakeBrokerClient.UpdateBrokerReturns(nil, nil)
@@ -493,7 +493,7 @@ var _ = Describe("Broker Handler", func() {
 				Expect(updateRequest).To(Equal(&platform.UpdateServiceBrokerRequest{
 					GUID:      smBrokerID,
 					Name:      brokerProxyName(brokerHandler.ProxyPrefix, newBrokerName, smBrokerID),
-					BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
+					BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
 				}))
 			})
 		})
@@ -503,7 +503,7 @@ var _ = Describe("Broker Handler", func() {
 				fakeBrokerClient.GetBrokerByNameReturns(&platform.ServiceBroker{
 					GUID:      smBrokerID,
 					Name:      brokerProxyName(brokerHandler.ProxyPrefix, smBrokerID, smBrokerID),
-					BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
+					BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
 				}, nil)
 
 			})
@@ -527,7 +527,7 @@ var _ = Describe("Broker Handler", func() {
 					expectedUpdateBrokerRequest = &platform.ServiceBroker{
 						GUID:      smBrokerID,
 						Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
-						BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
+						BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
 					}
 
 					fakeCatalogFetcher.FetchReturns(nil)
@@ -641,7 +641,7 @@ var _ = Describe("Broker Handler", func() {
 				fakeBrokerClient.GetBrokerByNameReturns(&platform.ServiceBroker{
 					GUID:      smBrokerID,
 					Name:      brokerHandler.ProxyPrefix + brokerName,
-					BrokerURL: brokerHandler.ProxyPath + "/" + smBrokerID,
+					BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
 				}, nil)
 			})
 

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -40,8 +40,8 @@ func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers, desir
 		return "", false
 	})
 	orphanProxyBrokerMap := indexBrokers(existingBrokers, func(broker *platform.ServiceBroker) (string, bool) {
-		if broker.BrokerURL == fmt.Sprint(r.proxyPathPattern, brokerIDFromURL(broker)) {
-			return r.brokerProxyName(broker), true
+		if broker.BrokerURL == fmt.Sprintf(r.proxyPathPattern, brokerIDFromURL(broker)) {
+			return broker.Name, true
 		}
 		return "", false
 	})

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -35,12 +35,16 @@ func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers, desir
 	})
 	proxyBrokerIDMap := indexBrokers(existingBrokers, func(broker *platform.ServiceBroker) (string, bool) {
 		if strings.HasPrefix(broker.BrokerURL, r.smPath) {
-			return broker.BrokerURL[strings.LastIndex(broker.BrokerURL, "/")+1:], true
+			return brokerIDFromURL(broker), true
 		}
 		return "", false
 	})
-	orphanProxyBrokerMap := indexBrokers(existingBrokers, func(broker platform.ServiceBroker) (string, bool) {
-		return r.brokerProxyName(&broker), true
+	orphanProxyBrokerMap := indexBrokers(existingBrokers, func(broker *platform.ServiceBroker) (string, bool) {
+		//		if broker.BrokerURL == (r.proxyPath + sbproxy.APIPrefix + "/" + brokerIDFromURL(&broker)) {
+		if broker.BrokerURL == fmt.Sprint(r.proxyPathPattern, brokerIDFromURL(broker)) {
+			return r.brokerProxyName(broker), true
+		}
+		return "", false
 	})
 
 	for _, desiredBroker := range desiredBrokers {
@@ -172,6 +176,10 @@ func logBroker(broker *platform.ServiceBroker) logrus.Fields {
 		"broker_name": broker.Name,
 		"broker_url":  broker.BrokerURL,
 	}
+}
+
+func brokerIDFromURL(broker *platform.ServiceBroker) string {
+	return broker.BrokerURL[strings.LastIndex(broker.BrokerURL, "/")+1:]
 }
 
 func getBrokerKey(broker *platform.ServiceBroker) string {

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -28,37 +28,36 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// reconcileBrokers attempts to reconcile the current brokers state in the platform (existingBrokers)
-// to match the desired broker state coming from the Service Manager (payloadBrokers).
-func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers, payloadBrokers []*platform.ServiceBroker) {
+// to match the desired broker state coming from the Service Manager (desiredBrokers).
+func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers, desiredBrokers []*platform.ServiceBroker) {
 	brokerKeyMap := indexBrokers(existingBrokers, func(broker *platform.ServiceBroker) (string, bool) {
 		return getBrokerKey(broker), true
 	})
 	proxyBrokerIDMap := indexBrokers(existingBrokers, func(broker *platform.ServiceBroker) (string, bool) {
-		if strings.HasPrefix(broker.BrokerURL, r.proxyPath) {
+		if strings.HasPrefix(broker.BrokerURL, r.smPath) {
 			return broker.BrokerURL[strings.LastIndex(broker.BrokerURL, "/")+1:], true
 		}
 		return "", false
 	})
 
-	for _, payloadBroker := range payloadBrokers {
-		payloadBroker := payloadBroker
-		existingBroker, alreadyProxified := proxyBrokerIDMap[payloadBroker.GUID]
-		delete(proxyBrokerIDMap, payloadBroker.GUID)
+	for _, desiredBroker := range desiredBrokers {
+		desiredBroker := desiredBroker
+		existingBroker, alreadyProxified := proxyBrokerIDMap[desiredBroker.GUID]
+		delete(proxyBrokerIDMap, desiredBroker.GUID)
 
-		platformBroker, shouldBeProxified := brokerKeyMap[getBrokerKey(payloadBroker)]
+		platformBroker, shouldBeProxified := brokerKeyMap[getBrokerKey(desiredBroker)]
 
 		if alreadyProxified {
-			if existingBroker.Name != r.brokerProxyName(payloadBroker) { // broker name has been changed in the platform
-				r.updateBrokerRegistration(ctx, existingBroker.GUID, payloadBroker)
+			if existingBroker.Name != r.brokerProxyName(desiredBroker) { // broker name has been changed in the platform
+				r.updateBrokerRegistration(ctx, existingBroker.GUID, desiredBroker)
 				continue
 			}
 			r.fetchBrokerCatalog(ctx, existingBroker)
 		} else {
 			if shouldBeProxified {
-				r.updateBrokerRegistration(ctx, platformBroker.GUID, payloadBroker)
+				r.updateBrokerRegistration(ctx, platformBroker.GUID, desiredBroker)
 			} else {
-				r.createBrokerRegistration(ctx, payloadBroker)
+				r.createBrokerRegistration(ctx, desiredBroker)
 			}
 		}
 	}
@@ -109,7 +108,7 @@ func (r *resyncJob) createBrokerRegistration(ctx context.Context, broker *platfo
 
 	createRequest := &platform.CreateServiceBrokerRequest{
 		Name:      r.brokerProxyName(broker),
-		BrokerURL: r.proxyPath + "/" + broker.GUID,
+		BrokerURL: r.smPath + "/" + broker.GUID,
 	}
 
 	if b, err := r.platformClient.Broker().CreateBroker(ctx, createRequest); err != nil {
@@ -126,7 +125,7 @@ func (r *resyncJob) updateBrokerRegistration(ctx context.Context, brokerGUID str
 	updateRequest := &platform.UpdateServiceBrokerRequest{
 		GUID:      brokerGUID,
 		Name:      r.brokerProxyName(broker),
-		BrokerURL: r.proxyPath + "/" + broker.GUID,
+		BrokerURL: r.smPath + "/" + broker.GUID,
 	}
 
 	if b, err := r.platformClient.Broker().UpdateBroker(ctx, updateRequest); err != nil {

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -40,7 +40,6 @@ func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers, desir
 		return "", false
 	})
 	orphanProxyBrokerMap := indexBrokers(existingBrokers, func(broker *platform.ServiceBroker) (string, bool) {
-		//		if broker.BrokerURL == (r.proxyPath + sbproxy.APIPrefix + "/" + brokerIDFromURL(&broker)) {
 		if broker.BrokerURL == fmt.Sprint(r.proxyPathPattern, brokerIDFromURL(broker)) {
 			return r.brokerProxyName(broker), true
 		}

--- a/pkg/sbproxy/reconcile/reconcile_brokers_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers_test.go
@@ -41,15 +41,19 @@ var _ = Describe("Reconcile brokers", func() {
 
 		reconciler *reconcile.Reconciler
 
-		smbroker1 *types.ServiceBroker
-		smbroker2 *types.ServiceBroker
-		smbroker3 *types.ServiceBroker
+		smbroker1      *types.ServiceBroker
+		smbroker2      *types.ServiceBroker
+		smbroker3      *types.ServiceBroker
+		smOrphanBroker *types.ServiceBroker
 
-		platformbroker1         *platform.ServiceBroker
-		platformbroker2         *platform.ServiceBroker
-		platformbrokerNonProxy  *platform.ServiceBroker
-		platformbrokerNonProxy2 *platform.ServiceBroker
-		platformBrokerProxy     *platform.ServiceBroker
+		platformbroker1                  *platform.ServiceBroker
+		platformbroker2                  *platform.ServiceBroker
+		platformbrokerNonProxy           *platform.ServiceBroker
+		platformbrokerNonProxy2          *platform.ServiceBroker
+		platformBrokerProxy              *platform.ServiceBroker
+		platformBrokerProxy2             *platform.ServiceBroker
+		platformOrphanBrokerProxy        *platform.ServiceBroker
+		platformOrphanBrokerProxyRenamed *platform.ServiceBroker
 	)
 
 	stubCreateBrokerToSucceed := func(ctx context.Context, r *platform.CreateServiceBrokerRequest) (*platform.ServiceBroker, error) {
@@ -70,8 +74,8 @@ var _ = Describe("Reconcile brokers", func() {
 		fakePlatformCatalogFetcher.FetchReturns(nil)
 	}
 
-	stubPlatformUpdateBroker := func() {
-		fakePlatformBrokerClient.UpdateBrokerReturns(platformBrokerProxy, nil)
+	stubPlatformUpdateBroker := func(broker *platform.ServiceBroker) {
+		fakePlatformBrokerClient.UpdateBrokerReturns(broker, nil)
 	}
 
 	BeforeEach(func() {
@@ -136,13 +140,13 @@ var _ = Describe("Reconcile brokers", func() {
 
 		platformbroker1 = &platform.ServiceBroker{
 			GUID:      "platformBrokerID1",
-			Name:      brokerProxyName("smBroker1", "smBrokerID1"),
+			Name:      brokerProxyName(smbroker1.Name, smbroker1.ID),
 			BrokerURL: fakeSMAppHost + "/" + smbroker1.ID,
 		}
 
 		platformbroker2 = &platform.ServiceBroker{
 			GUID:      "platformBrokerID2",
-			Name:      brokerProxyName("smBroker2", "smBrokerID2"),
+			Name:      brokerProxyName(smbroker2.Name, smbroker2.ID),
 			BrokerURL: fakeSMAppHost + "/" + smbroker2.ID,
 		}
 
@@ -150,6 +154,32 @@ var _ = Describe("Reconcile brokers", func() {
 			GUID:      platformbrokerNonProxy.GUID,
 			Name:      brokerProxyName(smbroker3.Name, smbroker3.ID),
 			BrokerURL: fakeSMAppHost + "/" + smbroker3.ID,
+		}
+
+		smOrphanBroker = &types.ServiceBroker{
+			Base: types.Base{
+				ID: "orphanBrokerProxyID",
+			},
+			Name:      "orphanBrokerProxy",
+			BrokerURL: "https://orphanbroker.com",
+		}
+
+		platformOrphanBrokerProxy = &platform.ServiceBroker{
+			GUID:      "platformOrphanBrokerProxy",
+			Name:      brokerProxyName(smOrphanBroker.Name, smOrphanBroker.ID),
+			BrokerURL: fakeProxyAppHost + "/v1/osb/" + smOrphanBroker.ID,
+		}
+
+		platformOrphanBrokerProxyRenamed = &platform.ServiceBroker{
+			GUID:      "platformOrphanBrokerProxy",
+			Name:      "test",
+			BrokerURL: fakeProxyAppHost + "/v1/osb/" + smOrphanBroker.ID,
+		}
+
+		platformBrokerProxy2 = &platform.ServiceBroker{
+			GUID:      platformOrphanBrokerProxy.GUID,
+			Name:      brokerProxyName(smOrphanBroker.Name, smOrphanBroker.ID),
+			BrokerURL: fakeSMAppHost + "/" + smOrphanBroker.ID,
 		}
 	})
 
@@ -314,6 +344,58 @@ var _ = Describe("Reconcile brokers", func() {
 			},
 		}),
 
+		Entry("When broker is in SM and is also in platform but points to proxy URL it should be updated to point to SM URL", testCase{
+			stubs: func() {
+				stubPlatformOpsToSucceed()
+				stubPlatformUpdateBroker(platformBrokerProxy2)
+			},
+			platformBrokers: func() ([]*platform.ServiceBroker, error) {
+				return []*platform.ServiceBroker{
+					platformOrphanBrokerProxy,
+				}, nil
+			},
+			smBrokers: func() ([]*types.ServiceBroker, error) {
+				return []*types.ServiceBroker{
+					smOrphanBroker,
+				}, nil
+			},
+			expectations: func() expectations {
+				return expectations{
+					reconcileCreateCalledFor: []*platform.ServiceBroker{},
+					reconcileDeleteCalledFor: []*platform.ServiceBroker{},
+					reconcileUpdateCalledFor: []*platform.ServiceBroker{
+						platformBrokerProxy2,
+					},
+				}
+			},
+		}),
+
+		Entry("When broker is in SM and is also in platform but points to proxy URL and was renamed in platform it should be updated to point to SM URL and name should be restored", testCase{
+			stubs: func() {
+				stubPlatformOpsToSucceed()
+				stubPlatformUpdateBroker(platformBrokerProxy2)
+			},
+			platformBrokers: func() ([]*platform.ServiceBroker, error) {
+				return []*platform.ServiceBroker{
+					platformOrphanBrokerProxyRenamed,
+				}, nil
+			},
+			smBrokers: func() ([]*types.ServiceBroker, error) {
+				return []*types.ServiceBroker{
+					smOrphanBroker,
+				}, nil
+			},
+			expectations: func() expectations {
+				return expectations{
+					reconcileCreateCalledFor: []*platform.ServiceBroker{},
+					reconcileDeleteCalledFor: []*platform.ServiceBroker{},
+					reconcileUpdateCalledFor: []*platform.ServiceBroker{
+						platformBrokerProxy2,
+					},
+				}
+			},
+		}),
+
 		Entry("When broker is missing from SM but is in platform it should be deleted", testCase{
 			stubs: func() {
 				stubPlatformOpsToSucceed()
@@ -362,7 +444,7 @@ var _ = Describe("Reconcile brokers", func() {
 		Entry("When broker is registered in the platform and SM, but not yet proxified, it should be updated", testCase{
 			stubs: func() {
 				stubPlatformOpsToSucceed()
-				stubPlatformUpdateBroker()
+				stubPlatformUpdateBroker(platformBrokerProxy)
 			},
 			platformBrokers: func() ([]*platform.ServiceBroker, error) {
 				return []*platform.ServiceBroker{
@@ -390,7 +472,7 @@ var _ = Describe("Reconcile brokers", func() {
 			// smBroker is registered in SM (as sm-smBroker-<id> in the platform), but it was renamed in the platform
 			stubs: func() {
 				stubPlatformOpsToSucceed()
-				stubPlatformUpdateBroker()
+				stubPlatformUpdateBroker(platformBrokerProxy)
 			},
 			platformBrokers: func() ([]*platform.ServiceBroker, error) {
 				return []*platform.ServiceBroker{

--- a/pkg/sbproxy/reconcile/reconcile_brokers_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers_test.go
@@ -19,7 +19,6 @@ package reconcile_test
 import (
 	"context"
 	"fmt"
-
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
@@ -32,7 +31,6 @@ import (
 )
 
 var _ = Describe("Reconcile brokers", func() {
-	const fakeAppHost = "https://smproxy.com"
 
 	var (
 		fakeSMClient *smfakes.FakeClient
@@ -97,7 +95,7 @@ var _ = Describe("Reconcile brokers", func() {
 		}
 
 		reconciler = &reconcile.Reconciler{
-			Resyncer: reconcile.NewResyncer(reconcile.DefaultSettings(), platformClient, fakeSMClient, fakeAppHost),
+			Resyncer: reconcile.NewResyncer(reconcile.DefaultSettings(), platformClient, fakeSMClient, fakeSMAppHost, fakeProxyPathPattern),
 		}
 
 		smbroker1 = &types.ServiceBroker{
@@ -139,19 +137,19 @@ var _ = Describe("Reconcile brokers", func() {
 		platformbroker1 = &platform.ServiceBroker{
 			GUID:      "platformBrokerID1",
 			Name:      brokerProxyName("smBroker1", "smBrokerID1"),
-			BrokerURL: fakeAppHost + "/" + smbroker1.ID,
+			BrokerURL: fakeSMAppHost + "/" + smbroker1.ID,
 		}
 
 		platformbroker2 = &platform.ServiceBroker{
 			GUID:      "platformBrokerID2",
 			Name:      brokerProxyName("smBroker2", "smBrokerID2"),
-			BrokerURL: fakeAppHost + "/" + smbroker2.ID,
+			BrokerURL: fakeSMAppHost + "/" + smbroker2.ID,
 		}
 
 		platformBrokerProxy = &platform.ServiceBroker{
 			GUID:      platformbrokerNonProxy.GUID,
 			Name:      brokerProxyName(smbroker3.Name, smbroker3.ID),
-			BrokerURL: fakeAppHost + "/" + smbroker3.ID,
+			BrokerURL: fakeSMAppHost + "/" + smbroker3.ID,
 		}
 	})
 

--- a/pkg/sbproxy/reconcile/reconcile_settings.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings.go
@@ -25,6 +25,8 @@ const DefaultProxyBrokerPrefix = "sm-"
 
 // Settings type represents the sbproxy settings
 type Settings struct {
+	AppName             string `mapstructure:"name"`
+	Domain              string `mapstructure:"domain"`
 	MaxParallelRequests int    `mapstructure:"max_parallel_requests"`
 	URL                 string `mapstructure:"url"`
 	BrokerPrefix        string `mapstructure:"broker_prefix"`
@@ -33,6 +35,8 @@ type Settings struct {
 // DefaultSettings creates default proxy settings
 func DefaultSettings() *Settings {
 	return &Settings{
+		AppName:             "",
+		Domain:              "",
 		MaxParallelRequests: 5,
 		URL:                 "",
 		BrokerPrefix:        DefaultProxyBrokerPrefix,
@@ -41,6 +45,12 @@ func DefaultSettings() *Settings {
 
 // Validate validates that the configuration contains all mandatory properties
 func (c *Settings) Validate() error {
+	if c.AppName == "" {
+		return fmt.Errorf("validate settings: missing app name")
+	}
+	if c.Domain == "" {
+		return fmt.Errorf("validate settings: missing app domain")
+	}
 	if c.URL == "" {
 		return fmt.Errorf("validate settings: missing url")
 	}

--- a/pkg/sbproxy/reconcile/reconcile_settings.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings.go
@@ -27,10 +27,7 @@ const DefaultProxyBrokerPrefix = "sm-"
 type Settings struct {
 	MaxParallelRequests int    `mapstructure:"max_parallel_requests"`
 	URL                 string `mapstructure:"url"`
-	Username            string `mapstructure:"username"`
-	Password            string `mapstructure:"password"`
-
-	BrokerPrefix string `mapstructure:"broker_prefix"`
+	BrokerPrefix        string `mapstructure:"broker_prefix"`
 }
 
 // DefaultSettings creates default proxy settings
@@ -38,8 +35,6 @@ func DefaultSettings() *Settings {
 	return &Settings{
 		MaxParallelRequests: 5,
 		URL:                 "",
-		Username:            "",
-		Password:            "",
 		BrokerPrefix:        DefaultProxyBrokerPrefix,
 	}
 }
@@ -48,12 +43,6 @@ func DefaultSettings() *Settings {
 func (c *Settings) Validate() error {
 	if c.URL == "" {
 		return fmt.Errorf("validate settings: missing url")
-	}
-	if len(c.Username) == 0 {
-		return fmt.Errorf("validate settings: missing username")
-	}
-	if len(c.Password) == 0 {
-		return fmt.Errorf("validate settings: missing password")
 	}
 	if c.MaxParallelRequests <= 0 {
 		return fmt.Errorf("validate settings: max parallel requests must be positive number")

--- a/pkg/sbproxy/reconcile/reconcile_settings.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings.go
@@ -25,8 +25,7 @@ const DefaultProxyBrokerPrefix = "sm-"
 
 // Settings type represents the sbproxy settings
 type Settings struct {
-	AppName             string `mapstructure:"name"`
-	Domain              string `mapstructure:"domain"`
+	LegacyURL           string `mapstructure:"legacy_url"`
 	MaxParallelRequests int    `mapstructure:"max_parallel_requests"`
 	URL                 string `mapstructure:"url"`
 	BrokerPrefix        string `mapstructure:"broker_prefix"`
@@ -35,8 +34,7 @@ type Settings struct {
 // DefaultSettings creates default proxy settings
 func DefaultSettings() *Settings {
 	return &Settings{
-		AppName:             "",
-		Domain:              "",
+		LegacyURL:           "",
 		MaxParallelRequests: 5,
 		URL:                 "",
 		BrokerPrefix:        DefaultProxyBrokerPrefix,
@@ -45,11 +43,8 @@ func DefaultSettings() *Settings {
 
 // Validate validates that the configuration contains all mandatory properties
 func (c *Settings) Validate() error {
-	if c.AppName == "" {
-		return fmt.Errorf("validate settings: missing app name")
-	}
-	if c.Domain == "" {
-		return fmt.Errorf("validate settings: missing app domain")
+	if c.LegacyURL == "" {
+		return fmt.Errorf("validate settings: missing legacy url")
 	}
 	if c.URL == "" {
 		return fmt.Errorf("validate settings: missing url")

--- a/pkg/sbproxy/reconcile/reconcile_settings_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings_test.go
@@ -25,6 +25,8 @@ import (
 
 func validSettings() *reconcile.Settings {
 	settings := reconcile.DefaultSettings()
+	settings.AppName = "service-broker-proxy"
+	settings.Domain = "domain.com"
 	settings.URL = "http://localhost:8080"
 	return settings
 }
@@ -35,6 +37,22 @@ var _ = Describe("Reconcile", func() {
 			Context("when all properties are set correctly", func() {
 				It("no error is returned", func() {
 					Expect(validSettings().Validate()).ShouldNot(HaveOccurred())
+				})
+			})
+
+			Context("when app name is missing", func() {
+				It("returns an error", func() {
+					settings := validSettings()
+					settings.AppName = ""
+					Expect(settings.Validate()).Should(HaveOccurred())
+				})
+			})
+
+			Context("when app domain is missing", func() {
+				It("returns an error", func() {
+					settings := validSettings()
+					settings.Domain = ""
+					Expect(settings.Validate()).Should(HaveOccurred())
 				})
 			})
 

--- a/pkg/sbproxy/reconcile/reconcile_settings_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings_test.go
@@ -26,8 +26,6 @@ import (
 func validSettings() *reconcile.Settings {
 	settings := reconcile.DefaultSettings()
 	settings.URL = "http://localhost:8080"
-	settings.Username = "user"
-	settings.Password = "password"
 	return settings
 }
 
@@ -44,22 +42,6 @@ var _ = Describe("Reconcile", func() {
 				It("returns an error", func() {
 					settings := validSettings()
 					settings.URL = ""
-					Expect(settings.Validate()).Should(HaveOccurred())
-				})
-			})
-
-			Context("when Username is missing", func() {
-				It("returns an error", func() {
-					settings := validSettings()
-					settings.Username = ""
-					Expect(settings.Validate()).Should(HaveOccurred())
-				})
-			})
-
-			Context("when Password is missing", func() {
-				It("returns an error", func() {
-					settings := validSettings()
-					settings.Password = ""
 					Expect(settings.Validate()).Should(HaveOccurred())
 				})
 			})

--- a/pkg/sbproxy/reconcile/reconcile_settings_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings_test.go
@@ -25,9 +25,8 @@ import (
 
 func validSettings() *reconcile.Settings {
 	settings := reconcile.DefaultSettings()
-	settings.AppName = "service-broker-proxy"
-	settings.Domain = "domain.com"
 	settings.URL = "http://localhost:8080"
+	settings.LegacyURL = "http://localhost:8080"
 	return settings
 }
 
@@ -40,18 +39,10 @@ var _ = Describe("Reconcile", func() {
 				})
 			})
 
-			Context("when app name is missing", func() {
+			Context("when LegacyURL is missing", func() {
 				It("returns an error", func() {
 					settings := validSettings()
-					settings.AppName = ""
-					Expect(settings.Validate()).Should(HaveOccurred())
-				})
-			})
-
-			Context("when app domain is missing", func() {
-				It("returns an error", func() {
-					settings := validSettings()
-					settings.Domain = ""
+					settings.LegacyURL = ""
 					Expect(settings.Validate()).Should(HaveOccurred())
 				})
 			})

--- a/pkg/sbproxy/reconcile/reconcile_suite_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_suite_test.go
@@ -18,12 +18,19 @@ package reconcile_test
 
 import (
 	"fmt"
+	"github.com/Peripli/service-broker-proxy/pkg/sbproxy"
 	"testing"
 
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+)
+
+const (
+	fakeSMAppHost        = "https://sm.com"
+	fakeProxyAppHost     = "https://smproxy.com"
+	fakeProxyPathPattern = fakeProxyAppHost + sbproxy.APIPrefix + "/%"
 )
 
 func TestReconcile(t *testing.T) {

--- a/pkg/sbproxy/reconcile/reconcile_suite_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_suite_test.go
@@ -30,7 +30,7 @@ import (
 const (
 	fakeSMAppHost        = "https://sm.com"
 	fakeProxyAppHost     = "https://smproxy.com"
-	fakeProxyPathPattern = fakeProxyAppHost + sbproxy.APIPrefix + "/%"
+	fakeProxyPathPattern = fakeProxyAppHost + sbproxy.APIPrefix + "/%s"
 )
 
 func TestReconcile(t *testing.T) {

--- a/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
@@ -35,7 +35,6 @@ import (
 
 var _ = Describe("Reconcile visibilities", func() {
 	const (
-		fakeAppHost         = "https://smproxy.com"
 		maxParallelRequests = 10
 		scopeKey            = "key"
 	)
@@ -119,7 +118,7 @@ var _ = Describe("Reconcile visibilities", func() {
 			result = append(result, &platform.ServiceBroker{
 				GUID:      "platformBrokerID1",
 				Name:      brokerProxyName(broker.Name, broker.ID),
-				BrokerURL: fakeAppHost + "/" + broker.ID,
+				BrokerURL: fakeSMAppHost + "/" + broker.ID,
 			})
 		}
 
@@ -223,7 +222,7 @@ var _ = Describe("Reconcile visibilities", func() {
 		settings := reconcile.DefaultSettings()
 		settings.MaxParallelRequests = maxParallelRequests
 		reconciler = &reconcile.Reconciler{
-			Resyncer: reconcile.NewResyncer(settings, fakePlatformClient, fakeSMClient, fakeAppHost),
+			Resyncer: reconcile.NewResyncer(settings, fakePlatformClient, fakeSMClient, fakeSMAppHost, fakeProxyPathPattern),
 		}
 
 		smBrokers = generateSMBrokers(2, 4, 100)

--- a/pkg/sbproxy/reconcile/resyncer.go
+++ b/pkg/sbproxy/reconcile/resyncer.go
@@ -14,12 +14,12 @@ import (
 
 // NewResyncer returns a resyncer that reconciles the state of the proxy brokers and visibilities
 // in the platform to match the desired state provided by the Service Manager.
-func NewResyncer(settings *Settings, platformClient platform.Client, smClient sm.Client, proxyPath string) Resyncer {
+func NewResyncer(settings *Settings, platformClient platform.Client, smClient sm.Client, smPath string) Resyncer {
 	return &resyncJob{
 		options:        settings,
 		platformClient: platformClient,
 		smClient:       smClient,
-		proxyPath:      proxyPath,
+		smPath:         smPath,
 	}
 }
 
@@ -27,7 +27,7 @@ type resyncJob struct {
 	options        *Settings
 	platformClient platform.Client
 	smClient       sm.Client
-	proxyPath      string
+	smPath         string
 }
 
 // Resync reconciles the state of the proxy brokers and visibilities at the platform

--- a/pkg/sbproxy/reconcile/resyncer.go
+++ b/pkg/sbproxy/reconcile/resyncer.go
@@ -14,20 +14,22 @@ import (
 
 // NewResyncer returns a resyncer that reconciles the state of the proxy brokers and visibilities
 // in the platform to match the desired state provided by the Service Manager.
-func NewResyncer(settings *Settings, platformClient platform.Client, smClient sm.Client, smPath string) Resyncer {
+func NewResyncer(settings *Settings, platformClient platform.Client, smClient sm.Client, smPath, proxyPathPattern string) Resyncer {
 	return &resyncJob{
-		options:        settings,
-		platformClient: platformClient,
-		smClient:       smClient,
-		smPath:         smPath,
+		options:          settings,
+		platformClient:   platformClient,
+		smClient:         smClient,
+		smPath:           smPath,
+		proxyPathPattern: proxyPathPattern,
 	}
 }
 
 type resyncJob struct {
-	options        *Settings
-	platformClient platform.Client
-	smClient       sm.Client
-	smPath         string
+	options          *Settings
+	platformClient   platform.Client
+	smClient         sm.Client
+	smPath           string
+	proxyPathPattern string
 }
 
 // Resync reconciles the state of the proxy brokers and visibilities at the platform

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -17,6 +17,7 @@
 package sbproxy
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/Peripli/service-manager/pkg/types"
@@ -140,7 +141,10 @@ func New(ctx context.Context, cancel context.CancelFunc, settings *Settings, pla
 		return nil, fmt.Errorf("error creating notifications producer: %s", err)
 	}
 	smPath := settings.Reconcile.URL + APIPrefix
-	proxyPathPattern := "https://" + settings.Reconcile.AppName + "." + settings.Reconcile.Domain + APIPrefix + "/%s"
+
+	protocol := strings.Split(settings.Reconcile.URL, "://")[0]
+	proxyPathPattern := protocol + "://" + settings.Reconcile.AppName + "." + settings.Reconcile.Domain + APIPrefix + "/%s"
+
 	resyncer := reconcile.NewResyncer(settings.Reconcile, platformClient, smClient, smPath, proxyPathPattern)
 	consumer := &notifications.Consumer{
 		Handlers: map[types.ObjectType]notifications.ResourceNotificationHandler{

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -139,8 +139,8 @@ func New(ctx context.Context, cancel context.CancelFunc, settings *Settings, pla
 	if err != nil {
 		return nil, fmt.Errorf("error creating notifications producer: %s", err)
 	}
-	smPath := settings.Sm.URL + APIPrefix
-	proxyPathPattern := settings.Reconcile.URL + APIPrefix + "/%s"
+	smPath := settings.Reconcile.URL + APIPrefix
+	proxyPathPattern := "https://" + settings.Reconcile.AppName + "." + settings.Reconcile.Domain + APIPrefix + "/%s"
 	resyncer := reconcile.NewResyncer(settings.Reconcile, platformClient, smClient, smPath, proxyPathPattern)
 	consumer := &notifications.Consumer{
 		Handlers: map[types.ObjectType]notifications.ResourceNotificationHandler{

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -17,7 +17,6 @@
 package sbproxy
 
 import (
-	"strings"
 	"sync"
 
 	"github.com/Peripli/service-manager/pkg/types"
@@ -140,10 +139,9 @@ func New(ctx context.Context, cancel context.CancelFunc, settings *Settings, pla
 	if err != nil {
 		return nil, fmt.Errorf("error creating notifications producer: %s", err)
 	}
-	smPath := settings.Reconcile.URL + APIPrefix
 
-	protocol := strings.Split(settings.Reconcile.URL, "://")[0]
-	proxyPathPattern := protocol + "://" + settings.Reconcile.AppName + "." + settings.Reconcile.Domain + APIPrefix + "/%s"
+	smPath := settings.Reconcile.URL + APIPrefix
+	proxyPathPattern := settings.Reconcile.LegacyURL + APIPrefix + "/%s"
 
 	resyncer := reconcile.NewResyncer(settings.Reconcile, platformClient, smClient, smPath, proxyPathPattern)
 	consumer := &notifications.Consumer{

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -124,7 +124,7 @@ func New(ctx context.Context, cancel context.CancelFunc, settings *Settings, pla
 		},
 		Filters: []web.Filter{
 			&filters.Logging{},
-			filter.NewBasicAuthnFilter(settings.Reconcile.Username, settings.Reconcile.Password),
+			filter.NewBasicAuthnFilter(settings.Sm.User, settings.Sm.Password),
 			secfilters.NewRequiredAuthnFilter(),
 		},
 		Registry: health.NewDefaultRegistry(),

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -139,15 +139,15 @@ func New(ctx context.Context, cancel context.CancelFunc, settings *Settings, pla
 	if err != nil {
 		return nil, fmt.Errorf("error creating notifications producer: %s", err)
 	}
-	proxyPath := settings.Reconcile.URL + APIPrefix
-	resyncer := reconcile.NewResyncer(settings.Reconcile, platformClient, smClient, proxyPath)
+	smPath := settings.Sm.URL + APIPrefix
+	resyncer := reconcile.NewResyncer(settings.Reconcile, platformClient, smClient, smPath)
 	consumer := &notifications.Consumer{
 		Handlers: map[types.ObjectType]notifications.ResourceNotificationHandler{
 			types.ServiceBrokerType: &handlers.BrokerResourceNotificationsHandler{
 				BrokerClient:   platformClient.Broker(),
 				CatalogFetcher: platformClient.CatalogFetcher(),
 				ProxyPrefix:    settings.Reconcile.BrokerPrefix,
-				ProxyPath:      proxyPath,
+				SMPath:         smPath,
 			},
 			types.VisibilityType: &handlers.VisibilityResourceNotificationsHandler{
 				VisibilityClient: platformClient.Visibility(),

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -140,7 +140,8 @@ func New(ctx context.Context, cancel context.CancelFunc, settings *Settings, pla
 		return nil, fmt.Errorf("error creating notifications producer: %s", err)
 	}
 	smPath := settings.Sm.URL + APIPrefix
-	resyncer := reconcile.NewResyncer(settings.Reconcile, platformClient, smClient, smPath)
+	proxyPathPattern := settings.Reconcile.URL + APIPrefix + "/%s"
+	resyncer := reconcile.NewResyncer(settings.Reconcile, platformClient, smClient, smPath, proxyPathPattern)
 	consumer := &notifications.Consumer{
 		Handlers: map[types.ObjectType]notifications.ResourceNotificationHandler{
 			types.ServiceBrokerType: &handlers.BrokerResourceNotificationsHandler{

--- a/pkg/sbproxy/sbproxy_test.go
+++ b/pkg/sbproxy/sbproxy_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Sbproxy", func() {
 			It("should panic", func() {
 				env, err := DefaultEnv(func(set *pflag.FlagSet) {
 					set.Set("app.url", "http://localhost:8080")
+					set.Set("app.legacy_url", "http://service-broker-proxy.domain.com")
 					set.Set("sm.user", "")
 					set.Set("sm.password", "admin")
 					set.Set("sm.url", "http://localhost:8080")
@@ -73,6 +74,7 @@ var _ = Describe("Sbproxy", func() {
 			It("should panic", func() {
 				env, err := DefaultEnv(func(set *pflag.FlagSet) {
 					set.Set("app.url", "http://localhost:8080")
+					set.Set("app.legacy_url", "http://service-broker-proxy.domain.com")
 					set.Set("sm.user", "")
 					set.Set("sm.password", "admin")
 					set.Set("sm.url", "http://localhost:8080")
@@ -94,8 +96,7 @@ var _ = Describe("Sbproxy", func() {
 				fakeBrokerClient.GetBrokersReturns([]*platform.ServiceBroker{}, nil)
 				env, err := DefaultEnv(func(set *pflag.FlagSet) {
 					set.Set("app.url", "http://localhost:8080")
-					set.Set("app.name", "service-broker-proxy")
-					set.Set("app.domain", "domain.com")
+					set.Set("app.legacy_url", "http://service-broker-proxy.domain.com")
 					set.Set("sm.user", "admin")
 					set.Set("sm.password", "admin")
 					set.Set("sm.url", "http://localhost:8080")

--- a/pkg/sbproxy/sbproxy_test.go
+++ b/pkg/sbproxy/sbproxy_test.go
@@ -94,8 +94,8 @@ var _ = Describe("Sbproxy", func() {
 				fakeBrokerClient.GetBrokersReturns([]*platform.ServiceBroker{}, nil)
 				env, err := DefaultEnv(func(set *pflag.FlagSet) {
 					set.Set("app.url", "http://localhost:8080")
-					set.Set("app.username", "admin")
-					set.Set("app.password", "admin")
+					set.Set("app.name", "service-broker-proxy")
+					set.Set("app.domain", "domain.com")
 					set.Set("sm.user", "admin")
 					set.Set("sm.password", "admin")
 					set.Set("sm.url", "http://localhost:8080")


### PR DESCRIPTION
# Register proxy broker URLs to point to SM instead of Proxy

## Motivation

The Service Broker Proxy component will no longer act as a proxy component for the respective platforms. It will still be responsible for reconciling and updating the state of the platforms, but OSB calls will now be directly go through the Service Manager.

## Approach

The Service Broker Proxy will register brokers in the platforms and will set as URL the SM URL instead of its own URL. Also the broker should be registered with the platform credentials retrieved when registering the respective platform. This is because now the platforms will directly call SM OSB APIs which are protected with basic authentication (platform credentials).

## Note

This change should take into account previously registered brokers with the proxy URL and update them accordingly.

## Progress

- [x] Use SM URL instead of SBP URL in broker registrations
- [x] Ensure old proxy brokers are gracefully updated/overtaken

## Linked to:

https://github.com/Peripli/service-broker-proxy-cf/pull/64