### PR TITLE
Add tests that resync job uses the same correlation id for all calls

### DIFF
--- a/pkg/sbproxy/reconcile/reconcile_brokers_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Peripli/service-manager/pkg/log"
-
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
 
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
@@ -527,64 +525,44 @@ var _ = Describe("Reconcile brokers", func() {
 
 		if err1 != nil {
 			Expect(len(fakePlatformBrokerClient.Invocations())).To(Equal(0))
-
 			Expect(len(fakePlatformCatalogFetcher.Invocations())).To(Equal(0))
-
 			Expect(fakeSMClient.GetBrokersCallCount()).To(Equal(1))
-			ctx := fakeSMClient.GetBrokersArgsForCall(0)
-			Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
-
 			return
 		}
 
 		if err2 != nil {
 			Expect(len(fakePlatformBrokerClient.Invocations())).To(Equal(1))
-			ctx := fakePlatformBrokerClient.GetBrokersArgsForCall(0)
-			Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
-
 			Expect(len(fakePlatformCatalogFetcher.Invocations())).To(Equal(0))
-
 			Expect(fakeSMClient.GetBrokersCallCount()).To(Equal(1))
-			ctx = fakeSMClient.GetBrokersArgsForCall(0)
-			Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
-
 			return
 		}
 
 		Expect(fakeSMClient.GetBrokersCallCount()).To(Equal(1))
-		ctx := fakeSMClient.GetBrokersArgsForCall(0)
-		Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
-
 		Expect(fakePlatformBrokerClient.GetBrokersCallCount()).To(Equal(1))
-		ctx = fakePlatformBrokerClient.GetBrokersArgsForCall(0)
-		Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
 
 		expected := t.expectations()
 		Expect(fakePlatformBrokerClient.CreateBrokerCallCount()).To(Equal(len(expected.reconcileCreateCalledFor)))
 		for index, broker := range expected.reconcileCreateCalledFor {
-			ctx, request := fakePlatformBrokerClient.CreateBrokerArgsForCall(index)
+			_, request := fakePlatformBrokerClient.CreateBrokerArgsForCall(index)
 			Expect(request).To(Equal(&platform.CreateServiceBrokerRequest{
 				Name:      broker.Name,
 				BrokerURL: broker.BrokerURL,
 			}))
-			Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
 		}
 
 		Expect(fakePlatformCatalogFetcher.FetchCallCount()).To(Equal(len(expected.reconcileCatalogCalledFor)))
 		for index, broker := range expected.reconcileCatalogCalledFor {
-			ctx, serviceBroker := fakePlatformCatalogFetcher.FetchArgsForCall(index)
+			_, serviceBroker := fakePlatformCatalogFetcher.FetchArgsForCall(index)
 			Expect(serviceBroker).To(Equal(broker))
-			Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
 		}
 
 		Expect(fakePlatformBrokerClient.DeleteBrokerCallCount()).To(Equal(len(expected.reconcileDeleteCalledFor)))
 		for index, broker := range expected.reconcileDeleteCalledFor {
-			ctx, request := fakePlatformBrokerClient.DeleteBrokerArgsForCall(index)
+			_, request := fakePlatformBrokerClient.DeleteBrokerArgsForCall(index)
 			Expect(request).To(Equal(&platform.DeleteServiceBrokerRequest{
 				GUID: broker.GUID,
 				Name: broker.Name,
 			}))
-			Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
 		}
 
 		Expect(fakePlatformBrokerClient.UpdateBrokerCallCount()).To(Equal(len(expected.reconcileUpdateCalledFor)))

--- a/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
@@ -22,8 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Peripli/service-manager/pkg/log"
-
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
 	"github.com/Peripli/service-broker-proxy/pkg/platform/platformfakes"
 	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
@@ -798,15 +796,12 @@ var _ = Describe("Reconcile visibilities", func() {
 		verifyInvocationsUseSameCorrelationID(invocations)
 
 		Expect(fakeSMClient.GetBrokersCallCount()).To(Equal(1))
-		ctx := fakeSMClient.GetBrokersArgsForCall(0)
-		Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
 
 		if t.enablePlanVisibilityCalledFor != nil {
 			visibilities := t.enablePlanVisibilityCalledFor()
 			Expect(fakeVisibilityClient.EnableAccessForPlanCallCount()).To(Equal(len(visibilities)))
 			for index := range t.enablePlanVisibilityCalledFor() {
-				ctx, request := fakeVisibilityClient.EnableAccessForPlanArgsForCall(index)
-				Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
+				_, request := fakeVisibilityClient.EnableAccessForPlanArgsForCall(index)
 				checkAccessArguments(request.Labels, request.CatalogPlanID, request.BrokerName, visibilities)
 			}
 		}
@@ -816,8 +811,7 @@ var _ = Describe("Reconcile visibilities", func() {
 			Expect(fakeVisibilityClient.DisableAccessForPlanCallCount()).To(Equal(len(visibilities)))
 
 			for index := range visibilities {
-				ctx, request := fakeVisibilityClient.DisableAccessForPlanArgsForCall(index)
-				Expect(log.CorrelationIDFromContext(ctx)).To(Not(BeEmpty()))
+				_, request := fakeVisibilityClient.DisableAccessForPlanArgsForCall(index)
 				checkAccessArguments(request.Labels, request.CatalogPlanID, request.BrokerName, visibilities)
 			}
 		}

--- a/pkg/sm/client_test.go
+++ b/pkg/sm/client_test.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Peripli/service-manager/pkg/log"
+
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/pkg/errors"
 
@@ -103,6 +105,8 @@ var _ = Describe("Client", func() {
 		})
 	})
 
+	const CorrelationIDValue = "corelation-id-value"
+
 	type testCase struct {
 		expectations *common.HTTPExpectations
 		reaction     *common.HTTPReaction
@@ -124,6 +128,13 @@ var _ = Describe("Client", func() {
 		})
 		Expect(err).ShouldNot(HaveOccurred())
 		return client
+	}
+
+	testContextWithCorrelationID := func(correlationID string) context.Context {
+		ctx := context.Background()
+
+		entry := log.C(ctx).WithField(log.FieldCorrelationID, correlationID)
+		return log.ContextWithLogger(ctx, entry)
 	}
 
 	assertResponse := func(t *testCase, resp interface{}, err error) {
@@ -167,7 +178,8 @@ var _ = Describe("Client", func() {
 			expectations: &common.HTTPExpectations{
 				URL: fmt.Sprintf(APIInternalBrokers, "http://example.com"),
 				Headers: map[string]string{
-					"Authorization": "Basic " + basicAuth("admin", "admin"),
+					"Authorization":             "Basic " + basicAuth("admin", "admin"),
+					log.CorrelationIDHeaders[0]: CorrelationIDValue,
 				},
 			},
 			reaction: &common.HTTPReaction{
@@ -183,7 +195,8 @@ var _ = Describe("Client", func() {
 			expectations: &common.HTTPExpectations{
 				URL: fmt.Sprintf(APIInternalBrokers, "http://example.com"),
 				Headers: map[string]string{
-					"Authorization": "Basic " + basicAuth("admin", "admin"),
+					"Authorization":             "Basic " + basicAuth("admin", "admin"),
+					log.CorrelationIDHeaders[0]: CorrelationIDValue,
 				},
 			},
 			reaction: &common.HTTPReaction{
@@ -198,7 +211,8 @@ var _ = Describe("Client", func() {
 			expectations: &common.HTTPExpectations{
 				URL: fmt.Sprintf(APIInternalBrokers, "http://example.com"),
 				Headers: map[string]string{
-					"Authorization": "Basic " + basicAuth("admin", "admin"),
+					"Authorization":             "Basic " + basicAuth("admin", "admin"),
+					log.CorrelationIDHeaders[0]: CorrelationIDValue,
 				},
 			},
 			reaction: &common.HTTPReaction{
@@ -214,7 +228,8 @@ var _ = Describe("Client", func() {
 			expectations: &common.HTTPExpectations{
 				URL: fmt.Sprintf(APIInternalBrokers, "http://example.com"),
 				Headers: map[string]string{
-					"Authorization": "Basic " + basicAuth("admin", "admin"),
+					"Authorization":             "Basic " + basicAuth("admin", "admin"),
+					log.CorrelationIDHeaders[0]: CorrelationIDValue,
 				},
 			},
 			reaction: &common.HTTPReaction{
@@ -229,7 +244,7 @@ var _ = Describe("Client", func() {
 
 	DescribeTable("GETBrokers", func(t testCase) {
 		client := newClient(&t)
-		resp, err := client.GetBrokers(context.TODO())
+		resp, err := client.GetBrokers(testContextWithCorrelationID(CorrelationIDValue))
 		assertResponse(&t, resp, err)
 	}, brokerEntries...)
 
@@ -268,7 +283,8 @@ var _ = Describe("Client", func() {
 			expectations: &common.HTTPExpectations{
 				URL: fmt.Sprintf(APIPlans, "http://example.com"),
 				Headers: map[string]string{
-					"Authorization": "Basic " + basicAuth("admin", "admin"),
+					"Authorization":             "Basic " + basicAuth("admin", "admin"),
+					log.CorrelationIDHeaders[0]: CorrelationIDValue,
 				},
 			},
 			reaction: &common.HTTPReaction{
@@ -284,7 +300,8 @@ var _ = Describe("Client", func() {
 			expectations: &common.HTTPExpectations{
 				URL: fmt.Sprintf(APIPlans, "http://example.com"),
 				Headers: map[string]string{
-					"Authorization": "Basic " + basicAuth("admin", "admin"),
+					"Authorization":             "Basic " + basicAuth("admin", "admin"),
+					log.CorrelationIDHeaders[0]: CorrelationIDValue,
 				},
 			},
 			reaction: &common.HTTPReaction{
@@ -299,7 +316,7 @@ var _ = Describe("Client", func() {
 
 	DescribeTable("GETPlans", func(t testCase) {
 		client := newClient(&t)
-		resp, err := client.GetPlans(context.TODO())
+		resp, err := client.GetPlans(testContextWithCorrelationID(CorrelationIDValue))
 		assertResponse(&t, resp, err)
 	}, planEntries...)
 
@@ -336,7 +353,8 @@ var _ = Describe("Client", func() {
 			expectations: &common.HTTPExpectations{
 				URL: fmt.Sprintf(APIVisibilities, "http://example.com"),
 				Headers: map[string]string{
-					"Authorization": "Basic " + basicAuth("admin", "admin"),
+					"Authorization":             "Basic " + basicAuth("admin", "admin"),
+					log.CorrelationIDHeaders[0]: CorrelationIDValue,
 				},
 			},
 			reaction: &common.HTTPReaction{
@@ -352,7 +370,8 @@ var _ = Describe("Client", func() {
 			expectations: &common.HTTPExpectations{
 				URL: fmt.Sprintf(APIVisibilities, "http://example.com"),
 				Headers: map[string]string{
-					"Authorization": "Basic " + basicAuth("admin", "admin"),
+					"Authorization":             "Basic " + basicAuth("admin", "admin"),
+					log.CorrelationIDHeaders[0]: CorrelationIDValue,
 				},
 			},
 			reaction: &common.HTTPReaction{
@@ -367,7 +386,7 @@ var _ = Describe("Client", func() {
 
 	DescribeTable("GETPlans", func(t testCase) {
 		client := newClient(&t)
-		resp, err := client.GetVisibilities(context.TODO())
+		resp, err := client.GetVisibilities(testContextWithCorrelationID(CorrelationIDValue))
 		assertResponse(&t, resp, err)
 	}, visibilitiesEntries...)
 })


### PR DESCRIPTION
Resync job already used the same correlation id for all calls but tests were missing. This PR adds the relevant tests