### PR TITLE
Add Broker takeover configuration

### DIFF
--- a/pkg/sbproxy/notifications/handlers/broker_handler.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler.go
@@ -95,7 +95,7 @@ func (bnh *BrokerResourceNotificationsHandler) OnCreate(ctx context.Context, pay
 	brokerProxyName := bnh.brokerProxyName(brokerToCreate.Resource)
 
 	if slice.StringsAnyEquals(bnh.BrokerBlacklist, brokerToCreate.Resource.Name) {
-		log.C(ctx).Infof("Broker with name %s is part of broker blacklist. Skipping notification...", brokerToCreate.Resource.Name)
+		log.C(ctx).Infof("Broker name %s for broker create notification is part of broker blacklist. Skipping notification...", brokerToCreate.Resource.Name)
 		return
 	}
 
@@ -165,7 +165,7 @@ func (bnh *BrokerResourceNotificationsHandler) OnUpdate(ctx context.Context, pay
 	}
 
 	if slice.StringsAnyEquals(bnh.BrokerBlacklist, brokerBeforeUpdate.Resource.Name) {
-		log.C(ctx).Infof("Broker with name %s is part of broker blacklist. Skipping notification...", brokerBeforeUpdate.Resource.Name)
+		log.C(ctx).Infof("Broker name %s for broker update notification is part of broker blacklist. Skipping notification...", brokerBeforeUpdate.Resource.Name)
 		return
 	}
 
@@ -233,7 +233,7 @@ func (bnh *BrokerResourceNotificationsHandler) OnDelete(ctx context.Context, pay
 	brokerProxyPath := bnh.brokerProxyPath(brokerToDelete.Resource)
 
 	if slice.StringsAnyEquals(bnh.BrokerBlacklist, brokerToDelete.Resource.Name) {
-		log.C(ctx).Infof("Broker with name %s is part of broker blacklist. Skipping notification...", brokerToDelete.Resource.Name)
+		log.C(ctx).Infof("Broker name %s for broker delete notification is part of broker blacklist. Skipping notification...", brokerToDelete.Resource.Name)
 		return
 	}
 

--- a/pkg/sbproxy/notifications/handlers/broker_handler.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler.go
@@ -159,10 +159,7 @@ func (bnh *BrokerResourceNotificationsHandler) OnUpdate(ctx context.Context, pay
 	brokerProxyNameAfter := bnh.brokerProxyName(brokerAfterUpdate.Resource)
 	brokerProxyPath := bnh.brokerProxyPath(brokerAfterUpdate.Resource)
 
-	brokerToFind := brokerProxyNameAfter
-	if brokerProxyNameBefore != brokerProxyNameAfter {
-		brokerToFind = brokerProxyNameBefore
-	}
+	brokerToFind := determineBrokerNameToFind(brokerProxyNameBefore, brokerProxyNameAfter)
 
 	if slice.StringsAnyEquals(bnh.BrokerBlacklist, brokerBeforeUpdate.Resource.Name) {
 		log.C(ctx).Infof("Broker name %s for broker update notification is part of broker blacklist. Skipping notification...", brokerBeforeUpdate.Resource.Name)
@@ -289,4 +286,11 @@ func (bnh *BrokerResourceNotificationsHandler) brokerProxyName(broker *types.Ser
 func shouldBeTakenOver(brokerFromPlatform *platform.ServiceBroker, brokerFromSM *types.ServiceBroker) bool {
 	return brokerFromPlatform.BrokerURL == brokerFromSM.BrokerURL &&
 		brokerFromPlatform.Name == brokerFromSM.Name
+}
+
+func determineBrokerNameToFind(oldBrokerName, newBrokerName string) string {
+	if oldBrokerName != newBrokerName {
+		return oldBrokerName
+	}
+	return newBrokerName
 }

--- a/pkg/sbproxy/notifications/handlers/broker_handler.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler.go
@@ -163,6 +163,12 @@ func (bnh *BrokerResourceNotificationsHandler) OnUpdate(ctx context.Context, pay
 	if brokerProxyNameBefore != brokerProxyNameAfter {
 		brokerToFind = brokerProxyNameBefore
 	}
+
+	if slice.StringsAnyEquals(bnh.BrokerBlacklist, brokerBeforeUpdate.Resource.Name) {
+		log.C(ctx).Infof("Broker with name %s is part of broker blacklist. Skipping notification...", brokerBeforeUpdate.Resource.Name)
+		return
+	}
+
 	log.C(ctx).Infof("Attempting to find platform broker with name %s in platform...", brokerToFind)
 	existingBroker, err := bnh.BrokerClient.GetBrokerByName(ctx, brokerToFind)
 	if err != nil {
@@ -225,6 +231,11 @@ func (bnh *BrokerResourceNotificationsHandler) OnDelete(ctx context.Context, pay
 	brokerToDelete := brokerPayload.Old
 	brokerProxyName := bnh.brokerProxyName(brokerToDelete.Resource)
 	brokerProxyPath := bnh.brokerProxyPath(brokerToDelete.Resource)
+
+	if slice.StringsAnyEquals(bnh.BrokerBlacklist, brokerToDelete.Resource.Name) {
+		log.C(ctx).Infof("Broker with name %s is part of broker blacklist. Skipping notification...", brokerToDelete.Resource.Name)
+		return
+	}
 
 	log.C(ctx).Infof("Attempting to find platform broker with name %s in platform...", brokerProxyName)
 

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -443,13 +443,27 @@ var _ = Describe("Broker Handler", func() {
 				}, nil)
 			})
 
-			It("does not try to create, update or delete broker", func() {
-				brokerHandler.OnUpdate(ctx, json.RawMessage(brokerNotificationPayload))
+			When("broker is not in broker blacklist", func() {
+				It("does not try to create, update or delete broker", func() {
+					brokerHandler.OnUpdate(ctx, json.RawMessage(brokerNotificationPayload))
 
-				Expect(fakeCatalogFetcher.FetchCallCount()).To(Equal(0))
-				Expect(fakeBrokerClient.CreateBrokerCallCount()).To(Equal(0))
-				Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
-				Expect(fakeBrokerClient.DeleteBrokerCallCount()).To(Equal(0))
+					Expect(fakeCatalogFetcher.FetchCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.CreateBrokerCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.DeleteBrokerCallCount()).To(Equal(0))
+				})
+			})
+
+			When("broker is in broker blacklist", func() {
+				It("does not try to create, update or delete broker", func() {
+					brokerHandler.BrokerBlacklist = []string{brokerName}
+					brokerHandler.OnUpdate(ctx, json.RawMessage(brokerNotificationPayload))
+
+					Expect(fakeCatalogFetcher.FetchCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.CreateBrokerCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.DeleteBrokerCallCount()).To(Equal(0))
+				})
 			})
 		})
 
@@ -652,13 +666,27 @@ var _ = Describe("Broker Handler", func() {
 				}, nil)
 			})
 
-			It("does not try to create, update or delete broker", func() {
-				brokerHandler.OnDelete(ctx, json.RawMessage(brokerNotificationPayload))
+			When("broker is not in broker blacklist", func() {
+				It("does not try to create, update or delete broker", func() {
+					brokerHandler.OnDelete(ctx, json.RawMessage(brokerNotificationPayload))
 
-				Expect(fakeCatalogFetcher.FetchCallCount()).To(Equal(0))
-				Expect(fakeBrokerClient.CreateBrokerCallCount()).To(Equal(0))
-				Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
-				Expect(fakeBrokerClient.DeleteBrokerCallCount()).To(Equal(0))
+					Expect(fakeCatalogFetcher.FetchCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.CreateBrokerCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.DeleteBrokerCallCount()).To(Equal(0))
+				})
+			})
+
+			When("broker is in broker blacklist", func() {
+				It("does not try to create, update or delete broker", func() {
+					brokerHandler.BrokerBlacklist = []string{brokerName}
+					brokerHandler.OnDelete(ctx, json.RawMessage(brokerNotificationPayload))
+
+					Expect(fakeCatalogFetcher.FetchCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.CreateBrokerCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
+					Expect(fakeBrokerClient.DeleteBrokerCallCount()).To(Equal(0))
+				})
 			})
 		})
 

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -71,10 +71,12 @@ var _ = Describe("Broker Handler", func() {
 		fakeBrokerClient = &platformfakes.FakeBrokerClient{}
 
 		brokerHandler = &handlers.BrokerResourceNotificationsHandler{
-			BrokerClient:   fakeBrokerClient,
-			CatalogFetcher: fakeCatalogFetcher,
-			ProxyPrefix:    "proxyPrefix",
-			SMPath:         "proxyPath",
+			BrokerClient:    fakeBrokerClient,
+			CatalogFetcher:  fakeCatalogFetcher,
+			ProxyPrefix:     "proxyPrefix",
+			SMPath:          "proxyPath",
+			BrokerBlacklist: []string{},
+			TakeoverEnabled: true,
 		}
 	})
 

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -230,16 +230,40 @@ var _ = Describe("Broker Handler", func() {
 				fakeBrokerClient.UpdateBrokerReturns(nil, fmt.Errorf("error"))
 			})
 
-			It("invokes update broker with the correct arguments", func() {
-				Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
-				brokerHandler.OnCreate(ctx, json.RawMessage(brokerNotificationPayload))
+			When("broker is not in broker blacklist", func() {
+				It("invokes update broker with the correct arguments", func() {
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
+					brokerHandler.OnCreate(ctx, json.RawMessage(brokerNotificationPayload))
 
-				Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(1))
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(1))
 
-				callCtx, callRequest := fakeBrokerClient.UpdateBrokerArgsForCall(0)
+					callCtx, callRequest := fakeBrokerClient.UpdateBrokerArgsForCall(0)
 
-				Expect(callCtx).To(Equal(ctx))
-				Expect(callRequest).To(Equal(expectedUpdateBrokerRequest))
+					Expect(callCtx).To(Equal(ctx))
+					Expect(callRequest).To(Equal(expectedUpdateBrokerRequest))
+				})
+			})
+
+			When("broker is in broker blacklist", func() {
+				It("doesn't invoke update broker", func() {
+					brokerHandler.BrokerBlacklist = []string{brokerName}
+
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
+					brokerHandler.OnCreate(ctx, json.RawMessage(brokerNotificationPayload))
+
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
+				})
+			})
+
+			When("broker takeover is disabled", func() {
+				It("invokes update broker with the correct arguments", func() {
+					brokerHandler.TakeoverEnabled = false
+
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
+					brokerHandler.OnCreate(ctx, json.RawMessage(brokerNotificationPayload))
+
+					Expect(fakeBrokerClient.UpdateBrokerCallCount()).To(Equal(0))
+				})
 			})
 		})
 

--- a/pkg/sbproxy/notifications/handlers/visibilities_handler.go
+++ b/pkg/sbproxy/notifications/handlers/visibilities_handler.go
@@ -240,6 +240,12 @@ func (vnh *VisibilityResourceNotificationsHandler) OnDelete(ctx context.Context,
 	}
 
 	v := visibilityPayload.Old
+
+	if slice.StringsAnyEquals(vnh.BrokerBlacklist, v.Additional.BrokerName) {
+		log.C(ctx).Infof("Broker name %s for the visibility create notification is part of broker blacklist. Skipping notification...", v.Additional.BrokerName)
+		return
+	}
+
 	platformBrokerName := vnh.brokerProxyName(v.Additional.BrokerName, v.Additional.BrokerID)
 
 	log.C(ctx).Infof("Attempting to disable access for plan with catalog ID %s for platform broker with name %s and labels %v...", v.Additional.ServicePlan.CatalogID, platformBrokerName, v.Resource.GetLabels())

--- a/pkg/sbproxy/notifications/handlers/visibilities_handler.go
+++ b/pkg/sbproxy/notifications/handlers/visibilities_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/util/slice"
 
 	"github.com/Peripli/service-manager/storage/interceptors"
 
@@ -71,7 +72,8 @@ func (vwad visibilityWithAdditionalDetails) Validate() error {
 type VisibilityResourceNotificationsHandler struct {
 	VisibilityClient platform.VisibilityClient
 
-	ProxyPrefix string
+	ProxyPrefix     string
+	BrokerBlacklist []string
 }
 
 // OnCreate creates visibilities from the specified notification payload by invoking the proper platform clients
@@ -95,6 +97,12 @@ func (vnh *VisibilityResourceNotificationsHandler) OnCreate(ctx context.Context,
 	}
 
 	v := visPayload.New
+
+	if slice.StringsAnyEquals(vnh.BrokerBlacklist, v.Additional.BrokerName) {
+		log.C(ctx).Infof("Broker name %s for the visibility create notification is part of broker blacklist. Skipping notification...", v.Additional.BrokerName)
+		return
+	}
+
 	platformBrokerName := vnh.brokerProxyName(v.Additional.BrokerName, v.Additional.BrokerID)
 
 	log.C(ctx).Infof("Attempting to enable access for plan with catalog ID %s for platform broker with name %s and labels %v...", v.Additional.ServicePlan.CatalogID, platformBrokerName, v.Resource.GetLabels())
@@ -132,6 +140,11 @@ func (vnh *VisibilityResourceNotificationsHandler) OnUpdate(ctx context.Context,
 
 	oldVisibilityPayload := visibilityPayload.Old
 	newVisibilityPayload := visibilityPayload.New
+
+	if slice.StringsAnyEquals(vnh.BrokerBlacklist, oldVisibilityPayload.Additional.BrokerName) {
+		log.C(ctx).Infof("Broker name %s for the visibility update notification is part of broker blacklist. Skipping notification...", oldVisibilityPayload.Additional.BrokerName)
+		return
+	}
 
 	platformBrokerName := vnh.brokerProxyName(oldVisibilityPayload.Additional.BrokerName, oldVisibilityPayload.Additional.BrokerID)
 

--- a/pkg/sbproxy/notifications/handlers/visibility_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/visibility_handler_test.go
@@ -237,6 +237,16 @@ var _ = Describe("Visibility Handler", func() {
 			})
 		})
 
+		Context("when the visibility notification is for a broker which is in the broker blacklist", func() {
+			It("does not try to enable or disable access", func() {
+				visibilityHandler.BrokerBlacklist = []string{smBrokerName}
+				visibilityHandler.OnCreate(ctx, json.RawMessage(visibilityNotificationPayload))
+
+				Expect(fakeVisibilityClient.EnableAccessForPlanCallCount()).To(Equal(0))
+				Expect(fakeVisibilityClient.DisableAccessForPlanCallCount()).To(Equal(0))
+			})
+		})
+
 		Context("when the notification payload is valid", func() {
 			Context("when an error occurs while enabling access", func() {
 				BeforeEach(func() {
@@ -377,6 +387,16 @@ var _ = Describe("Visibility Handler", func() {
 			})
 
 			It("does not try to enable or disable access", func() {
+				visibilityHandler.OnUpdate(ctx, json.RawMessage(visibilityNotificationPayload))
+
+				Expect(fakeVisibilityClient.EnableAccessForPlanCallCount()).To(Equal(0))
+				Expect(fakeVisibilityClient.DisableAccessForPlanCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when the visibility notification is for a broker which is in the broker blacklist", func() {
+			It("does not try to enable or disable access", func() {
+				visibilityHandler.BrokerBlacklist = []string{smBrokerName}
 				visibilityHandler.OnUpdate(ctx, json.RawMessage(visibilityNotificationPayload))
 
 				Expect(fakeVisibilityClient.EnableAccessForPlanCallCount()).To(Equal(0))
@@ -620,6 +640,16 @@ var _ = Describe("Visibility Handler", func() {
 					Expect(fakeVisibilityClient.EnableAccessForPlanCallCount()).To(Equal(0))
 					Expect(fakeVisibilityClient.DisableAccessForPlanCallCount()).To(Equal(0))
 				})
+			})
+		})
+
+		Context("when the visibility notification is for a broker which is in the broker blacklist", func() {
+			It("does not try to enable or disable access", func() {
+				visibilityHandler.BrokerBlacklist = []string{smBrokerName}
+				visibilityHandler.OnDelete(ctx, json.RawMessage(visibilityNotificationPayload))
+
+				Expect(fakeVisibilityClient.EnableAccessForPlanCallCount()).To(Equal(0))
+				Expect(fakeVisibilityClient.DisableAccessForPlanCallCount()).To(Equal(0))
 			})
 		})
 

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -62,7 +62,9 @@ func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers, desir
 			platformBroker, shouldBeProxified := brokerKeyMap[getBrokerKey(desiredBroker)]
 
 			if shouldBeProxified {
-				r.updateBrokerRegistration(ctx, platformBroker.GUID, desiredBroker)
+				if r.options.TakeoverEnabled {
+					r.updateBrokerRegistration(ctx, platformBroker.GUID, desiredBroker)
+				}
 			} else {
 				r.createBrokerRegistration(ctx, desiredBroker)
 			}

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -49,19 +49,19 @@ func (r *resyncJob) reconcileBrokers(ctx context.Context, existingBrokers, desir
 
 	for _, desiredBroker := range desiredBrokers {
 		desiredBroker := desiredBroker
-		existingBroker, alreadyProxified := proxyBrokerIDMap[desiredBroker.GUID]
+		existingBroker, alreadyTakenOver := proxyBrokerIDMap[desiredBroker.GUID]
 		delete(proxyBrokerIDMap, desiredBroker.GUID)
 
-		if alreadyProxified {
+		if alreadyTakenOver {
 			if existingBroker.Name != r.brokerProxyName(desiredBroker) || !strings.HasPrefix(existingBroker.BrokerURL, r.smPath) { // broker name has been changed in the platform or broker proxy URL should be updated
 				r.updateBrokerRegistration(ctx, existingBroker.GUID, desiredBroker)
 				continue
 			}
 			r.fetchBrokerCatalog(ctx, existingBroker)
 		} else {
-			platformBroker, shouldBeProxified := brokerKeyMap[getBrokerKey(desiredBroker)]
+			platformBroker, shouldBeTakenOver := brokerKeyMap[getBrokerKey(desiredBroker)]
 
-			if shouldBeProxified {
+			if shouldBeTakenOver {
 				if r.options.TakeoverEnabled {
 					r.updateBrokerRegistration(ctx, platformBroker.GUID, desiredBroker)
 				}

--- a/pkg/sbproxy/reconcile/reconcile_brokers_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers_test.go
@@ -547,7 +547,7 @@ var _ = Describe("Reconcile brokers", func() {
 			},
 		}),
 
-		Entry("When broker is registered in the platform and SM, but not yet proxified, it should be updated", testCase{
+		Entry("When broker is registered in the platform and SM, but not yet taken over, it should be updated", testCase{
 			stubs: func() {
 				stubPlatformUpdateBroker(platformBrokerProxy)
 			},
@@ -578,7 +578,7 @@ var _ = Describe("Reconcile brokers", func() {
 			},
 		}),
 
-		Entry("When broker is registered in the platform and SM, but not yet proxified, but is also in the proxy broker blacklist it should be ignored", testCase{
+		Entry("When broker is registered in the platform and SM, but not yet taken over, but is also in the proxy broker blacklist it should be ignored", testCase{
 			stubs: func() {},
 			platformBrokers: func() ([]*platform.ServiceBroker, error) {
 				return []*platform.ServiceBroker{
@@ -605,7 +605,7 @@ var _ = Describe("Reconcile brokers", func() {
 			},
 		}),
 
-		Entry("When all brokers are registered in the platform and SM, but not yet proxified, but are also in the proxy broker blacklist they should be ignored", testCase{
+		Entry("When all brokers are registered in the platform and SM, but not yet taken over, but are also in the proxy broker blacklist they should be ignored", testCase{
 			stubs: func() {},
 			platformBrokers: func() ([]*platform.ServiceBroker, error) {
 				return []*platform.ServiceBroker{
@@ -633,7 +633,7 @@ var _ = Describe("Reconcile brokers", func() {
 			},
 		}),
 
-		Entry("When broker is registered in the platform and SM, but not yet proxified, and takeover is disabled it should not be proxified", testCase{
+		Entry("When broker is registered in the platform and SM, but not yet taken over, and takeover is disabled it should not be taken over", testCase{
 			stubs: func() {
 				stubPlatformOpsToSucceed()
 				stubPlatformUpdateBroker(platformBrokerProxy)
@@ -663,7 +663,7 @@ var _ = Describe("Reconcile brokers", func() {
 			},
 		}),
 
-		Entry("When all brokers are registered in the platform and SM, but not yet proxified, and takeover is disabled they should not be proxified", testCase{
+		Entry("When all brokers are registered in the platform and SM, but not yet taken over, and takeover is disabled they should not be taken over", testCase{
 			stubs: func() {
 				stubPlatformOpsToSucceed()
 				stubPlatformUpdateBroker(platformBrokerProxy)

--- a/pkg/sbproxy/reconcile/reconcile_brokers_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers_test.go
@@ -207,6 +207,7 @@ var _ = Describe("Reconcile brokers", func() {
 		platformBrokers func() ([]*platform.ServiceBroker, error)
 		smBrokers       func() ([]*types.ServiceBroker, error)
 		brokerBlacklist func() []string
+		takeoverEnabled bool
 
 		expectations func() expectations
 	}
@@ -225,6 +226,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor:  []*platform.ServiceBroker{},
@@ -247,6 +249,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor:  []*platform.ServiceBroker{},
@@ -275,6 +278,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor: []*platform.ServiceBroker{
@@ -307,6 +311,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor: []*platform.ServiceBroker{},
@@ -335,6 +340,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor: []*platform.ServiceBroker{
@@ -363,6 +369,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{smbroker1.Name}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor: []*platform.ServiceBroker{
@@ -388,6 +395,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{smbroker1.Name, smbroker2.Name}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor:  []*platform.ServiceBroker{},
@@ -414,6 +422,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor: []*platform.ServiceBroker{},
@@ -443,6 +452,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor: []*platform.ServiceBroker{},
@@ -472,6 +482,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor: []*platform.ServiceBroker{},
@@ -498,6 +509,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor: []*platform.ServiceBroker{},
@@ -525,6 +537,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor:  []*platform.ServiceBroker{},
@@ -552,6 +565,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor:  []*platform.ServiceBroker{},
@@ -580,6 +594,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{smbroker3.Name}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor:  []*platform.ServiceBroker{},
@@ -604,9 +619,71 @@ var _ = Describe("Reconcile brokers", func() {
 					smbroker4,
 				}, nil
 			},
+			takeoverEnabled: true,
 			brokerBlacklist: func() []string {
 				return []string{smbroker3.Name, smbroker4.Name}
 			},
+			expectations: func() expectations {
+				return expectations{
+					reconcileCreateCalledFor:  []*platform.ServiceBroker{},
+					reconcileDeleteCalledFor:  []*platform.ServiceBroker{},
+					reconcileCatalogCalledFor: []*platform.ServiceBroker{},
+					reconcileUpdateCalledFor:  []*platform.ServiceBroker{},
+				}
+			},
+		}),
+
+		Entry("When broker is registered in the platform and SM, but not yet proxified, and takeover is disabled it should not be proxified", testCase{
+			stubs: func() {
+				stubPlatformOpsToSucceed()
+				stubPlatformUpdateBroker(platformBrokerProxy)
+			},
+			platformBrokers: func() ([]*platform.ServiceBroker, error) {
+				return []*platform.ServiceBroker{
+					platformbrokerNonProxy,
+					platformbrokerNonProxy2,
+				}, nil
+			},
+			smBrokers: func() ([]*types.ServiceBroker, error) {
+				return []*types.ServiceBroker{
+					smbroker3,
+				}, nil
+			},
+			brokerBlacklist: func() []string {
+				return []string{}
+			},
+			takeoverEnabled: false,
+			expectations: func() expectations {
+				return expectations{
+					reconcileCreateCalledFor:  []*platform.ServiceBroker{},
+					reconcileDeleteCalledFor:  []*platform.ServiceBroker{},
+					reconcileCatalogCalledFor: []*platform.ServiceBroker{},
+					reconcileUpdateCalledFor:  []*platform.ServiceBroker{},
+				}
+			},
+		}),
+
+		Entry("When all brokers are registered in the platform and SM, but not yet proxified, and takeover is disabled they should not be proxified", testCase{
+			stubs: func() {
+				stubPlatformOpsToSucceed()
+				stubPlatformUpdateBroker(platformBrokerProxy)
+			},
+			platformBrokers: func() ([]*platform.ServiceBroker, error) {
+				return []*platform.ServiceBroker{
+					platformbrokerNonProxy,
+					platformbrokerNonProxy2,
+				}, nil
+			},
+			smBrokers: func() ([]*types.ServiceBroker, error) {
+				return []*types.ServiceBroker{
+					smbroker3,
+					smbroker4,
+				}, nil
+			},
+			brokerBlacklist: func() []string {
+				return []string{}
+			},
+			takeoverEnabled: false,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor:  []*platform.ServiceBroker{},
@@ -642,6 +719,7 @@ var _ = Describe("Reconcile brokers", func() {
 			brokerBlacklist: func() []string {
 				return []string{}
 			},
+			takeoverEnabled: true,
 			expectations: func() expectations {
 				return expectations{
 					reconcileCreateCalledFor: []*platform.ServiceBroker{},
@@ -670,6 +748,7 @@ var _ = Describe("Reconcile brokers", func() {
 		t.stubs()
 
 		reconcileSettings.BrokerBlacklist = t.brokerBlacklist()
+		reconcileSettings.TakeoverEnabled = t.takeoverEnabled
 		reconciler.Resyncer.Resync(context.TODO())
 
 		invocations := append([]map[string][][]interface{}{}, fakeSMClient.Invocations(), fakePlatformCatalogFetcher.Invocations(), fakePlatformBrokerClient.Invocations())

--- a/pkg/sbproxy/reconcile/reconcile_settings.go
+++ b/pkg/sbproxy/reconcile/reconcile_settings.go
@@ -30,6 +30,7 @@ type Settings struct {
 	URL                 string   `mapstructure:"url"`
 	BrokerPrefix        string   `mapstructure:"broker_prefix"`
 	BrokerBlacklist     []string `mapstructure:"broker_blacklist"`
+	TakeoverEnabled     bool     `mapstructure:"takeover_enabled"`
 }
 
 // DefaultSettings creates default proxy settings
@@ -40,6 +41,7 @@ func DefaultSettings() *Settings {
 		URL:                 "",
 		BrokerPrefix:        DefaultProxyBrokerPrefix,
 		BrokerBlacklist:     []string{},
+		TakeoverEnabled:     true,
 	}
 }
 

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -144,6 +144,7 @@ func New(ctx context.Context, cancel context.CancelFunc, settings *Settings, pla
 			types.VisibilityType: &handlers.VisibilityResourceNotificationsHandler{
 				VisibilityClient: platformClient.Visibility(),
 				ProxyPrefix:      settings.Reconcile.BrokerPrefix,
+				BrokerBlacklist:  settings.Reconcile.BrokerBlacklist,
 			},
 		},
 	}

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -139,6 +139,7 @@ func New(ctx context.Context, cancel context.CancelFunc, settings *Settings, pla
 				ProxyPrefix:     settings.Reconcile.BrokerPrefix,
 				SMPath:          smPath,
 				BrokerBlacklist: settings.Reconcile.BrokerBlacklist,
+				TakeoverEnabled: settings.Reconcile.TakeoverEnabled,
 			},
 			types.VisibilityType: &handlers.VisibilityResourceNotificationsHandler{
 				VisibilityClient: platformClient.Visibility(),

--- a/pkg/sbproxy/sbproxy.go
+++ b/pkg/sbproxy/sbproxy.go
@@ -134,10 +134,11 @@ func New(ctx context.Context, cancel context.CancelFunc, settings *Settings, pla
 	consumer := &notifications.Consumer{
 		Handlers: map[types.ObjectType]notifications.ResourceNotificationHandler{
 			types.ServiceBrokerType: &handlers.BrokerResourceNotificationsHandler{
-				BrokerClient:   platformClient.Broker(),
-				CatalogFetcher: platformClient.CatalogFetcher(),
-				ProxyPrefix:    settings.Reconcile.BrokerPrefix,
-				SMPath:         smPath,
+				BrokerClient:    platformClient.Broker(),
+				CatalogFetcher:  platformClient.CatalogFetcher(),
+				ProxyPrefix:     settings.Reconcile.BrokerPrefix,
+				SMPath:          smPath,
+				BrokerBlacklist: settings.Reconcile.BrokerBlacklist,
 			},
 			types.VisibilityType: &handlers.VisibilityResourceNotificationsHandler{
 				VisibilityClient: platformClient.Visibility(),


### PR DESCRIPTION
# Add Broker takeover configuration

In cases where takeover of platform brokers needs to be centrally disabled there needs to be a configuration property to do that.