### PR TITLE
Downgrade to Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.12.x
+  - 1.11.x
 
 before_install:
   - go get -u github.com/golang/dep/cmd/dep


### PR DESCRIPTION
# Downgrade to Go 1.11

Motivation: https://github.com/golang/go/issues/35373