### PR TITLE
[ADOPTION] Accept web.Request instead of http.Request in Authenticator interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -24,7 +24,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "authenticator-req"
+  branch = "master"
   digest = "1:31a802b7fe1a482dbabe830bd0125033fd298a10da211e8051bd76ec8fa9e748"
   name = "github.com/Peripli/service-manager"
   packages = [
@@ -70,7 +70,7 @@
     "test/testutil",
   ]
   pruneopts = "NT"
-  revision = "1af52a4f54a1fabad4195de6fcc4b8920b0cec44"
+  revision = "4623a495d1d96fe95b3c73dc78749dc277d806db"
 
 [[projects]]
   digest = "1:f780d408067189c4c42b53f7bb24ebf8fd2a1e4510b813ed6e79dd6563e38cc5"
@@ -660,11 +660,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f4caa38f81f81dc7832d923b152eddd743c2f088ef0269bcd6cba53ce5851485"
+  digest = "1:578046baf093df15df2904bbb0fe06f3f2385bad59987532201007754aa7e1d5"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "cb0a6d8edb6c3528b01a0be84a5fe513dbf880a6"
+  revision = "d5e6a3e2c0ae16fc7480523ebcb7fd4dd3215489"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -24,7 +24,8 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:375f6f69e64f143bf4b36c76267525b0856ea2ddb0c77dd6e820c40bd38fe3e9"
+  branch = "authenticator-req"
+  digest = "1:31a802b7fe1a482dbabe830bd0125033fd298a10da211e8051bd76ec8fa9e748"
   name = "github.com/Peripli/service-manager"
   packages = [
     "api",
@@ -69,8 +70,7 @@
     "test/testutil",
   ]
   pruneopts = "NT"
-  revision = "fe1b4ba4cd5f95f18c277d3067f7accb682f4743"
-  version = "v0.10.0"
+  revision = "1af52a4f54a1fabad4195de6fcc4b8920b0cec44"
 
 [[projects]]
   digest = "1:f780d408067189c4c42b53f7bb24ebf8fd2a1e4510b813ed6e79dd6563e38cc5"
@@ -290,7 +290,7 @@
   revision = "2ba0fc60eb4a54030f3a6d73ff0a047349c7eeca"
 
 [[projects]]
-  digest = "1:1d965d8955ca44e9c963e24fdf0517033ca1820b6643ec546106dc2040ed54a0"
+  digest = "1:da22f8cea639e4c5a5df6a1604fe33396ee2cea130b8214ba67cb6ad236b87ff"
   name = "github.com/klauspost/compress"
   packages = [
     "flate",
@@ -298,8 +298,8 @@
     "zlib",
   ]
   pruneopts = "UT"
-  revision = "b9d5dc7bd435c628cb0c658ce7f556409007ea71"
-  version = "v1.10.0"
+  revision = "2a5ec94050832300f2c49529dbab4b3774cbc30a"
+  version = "v1.10.1"
 
 [[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
@@ -506,15 +506,15 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:99d32780e5238c2621fff621123997c3e3cca96db8be13179013aea77dfab551"
+  digest = "1:49b1087f45b1e49687da2f8eb49d9e07919d4bad3813344251c722141dcb31d6"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "require",
   ]
   pruneopts = "UT"
-  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
-  version = "v1.4.0"
+  revision = "3ebf1ddaeb260c4b1ae502a01c7844fa8c1fa0e9"
+  version = "v1.5.1"
 
 [[projects]]
   digest = "1:13503b1b68ee704913caf452f02968fa313a9934e67d951ed0d39ca8e230d5e0"
@@ -629,7 +629,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "86ce3cb696783b739e41e834e2eead3e1b4aa3fb"
+  revision = "2aa609cf4a9d7d1126360de73b55b6002f9e052a"
 
 [[projects]]
   branch = "master"
@@ -645,7 +645,7 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "16171245cfb220d5317888b716d69c1fb4e7992b"
+  revision = "5a598a2470a0279bd28bab287167dc1ef0813153"
 
 [[projects]]
   branch = "master"
@@ -660,11 +660,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:72b7c210f8cfe1431d2f300fbf37f25e52aa77324b05ab6b698483054033803e"
+  digest = "1:f4caa38f81f81dc7832d923b152eddd743c2f088ef0269bcd6cba53ce5851485"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "d101bd2416d505c0448a6ce8a282482678040a89"
+  revision = "cb0a6d8edb6c3528b01a0be84a5fe513dbf880a6"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  version = "=0.10.0"
+  branch = "authenticator-req"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
 [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/Peripli/service-manager"
-  branch = "authenticator-req"
+  branch = "master"
 
 # Refer to issue https://github.com/golang/dep/issues/1799
 [[override]]

--- a/pkg/authn/basic.go
+++ b/pkg/authn/basic.go
@@ -18,8 +18,6 @@ package authn
 
 import (
 	"fmt"
-	"net/http"
-
 	httpsec "github.com/Peripli/service-manager/pkg/security/http"
 
 	"github.com/Peripli/service-manager/pkg/web"
@@ -38,7 +36,7 @@ type inmemoryBasicAuthenticator struct {
 	expectedPassword string
 }
 
-func (a *inmemoryBasicAuthenticator) Authenticate(request *http.Request) (*web.UserContext, httpsec.Decision, error) {
+func (a *inmemoryBasicAuthenticator) Authenticate(request *web.Request) (*web.UserContext, httpsec.Decision, error) {
 	username, password, ok := request.BasicAuth()
 	if !ok {
 		return nil, httpsec.Abstain, nil

--- a/pkg/authn/basic_test.go
+++ b/pkg/authn/basic_test.go
@@ -17,6 +17,7 @@
 package authn
 
 import (
+	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
 
 	httpsec "github.com/Peripli/service-manager/pkg/security/http"
@@ -52,7 +53,7 @@ var _ = Describe("Basic Authentication wrapper", func() {
 		func(expectedDecision httpsec.Decision, expectsError bool, username, password string) {
 
 			request := newRequest(username, password)
-			_, decision, err := basic.Authenticate(request)
+			_, decision, err := basic.Authenticate(&web.Request{Request: request})
 			if expectsError {
 				Expect(err).To(HaveOccurred())
 				Expect(decision).To(Equal(expectedDecision))


### PR DESCRIPTION
#  Accept web.Request instead of http.Request in Authenticator interface

## Motivation

https://github.com/Peripli/service-manager/pull/442

## Pull Request status

* [x] Initial implementation