### PR TITLE
Fix large logs

### DIFF
--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -134,7 +134,7 @@ func (r *resyncJob) getBrokersFromSM(ctx context.Context) ([]*platform.ServiceBr
 		}
 		brokersFromSM = append(brokersFromSM, brokerReg)
 	}
-	logger.Infof("resyncJob SUCCESSFULLY retrieved %d brokers from Service Manager", len(brokersFromSM))
+	logger.Infof("resyncJob successfully retrieved %d brokers from Service Manager", len(brokersFromSM))
 
 	return brokersFromSM, nil
 }
@@ -175,7 +175,7 @@ func (r *resyncJob) fetchBrokerCatalog(ctx context.Context, brokerGUIDInPlatform
 			logger.WithFields(logBroker(brokerInSM)).WithError(err).Error("Error during fetching catalog...")
 			return err
 		}
-		logger.WithFields(logBroker(brokerInSM)).Info("resyncJob SUCCESSFULLY refetched catalog for broker")
+		logger.WithFields(logBroker(brokerInSM)).Info("resyncJob successfully refetched catalog for broker")
 	}
 	return nil
 }
@@ -208,7 +208,7 @@ func (r *resyncJob) createBrokerRegistration(ctx context.Context, brokerInSM *pl
 		logger.WithFields(logBroker(brokerInSM)).WithError(err).Error("Error during broker creation")
 		return err
 	}
-	logger.WithFields(logBroker(b)).Infof("resyncJob SUCCESSFULLY created proxy for broker at platform under name [%s] accessible at [%s]", createRequest.Name, createRequest.BrokerURL)
+	logger.WithFields(logBroker(b)).Infof("resyncJob successfully created proxy for broker at platform under name [%s] accessible at [%s]", createRequest.Name, createRequest.BrokerURL)
 	return nil
 }
 
@@ -246,7 +246,7 @@ func (r *resyncJob) updateBrokerRegistration(ctx context.Context, brokerGUIDInPl
 		logger.WithFields(logBroker(brokerInSM)).WithError(err).Error("Error during broker update")
 		return err
 	}
-	logger.WithFields(logBroker(b)).Infof("resyncJob SUCCESSFULLY updated broker registration at platform under name [%s] accessible at [%s]", updateRequest.Name, updateRequest.BrokerURL)
+	logger.WithFields(logBroker(b)).Infof("resyncJob successfully updated broker registration at platform under name [%s] accessible at [%s]", updateRequest.Name, updateRequest.BrokerURL)
 	return nil
 }
 
@@ -264,7 +264,7 @@ func (r *resyncJob) deleteBrokerRegistration(ctx context.Context, broker *platfo
 		return err
 	}
 
-	logger.WithFields(logBroker(broker)).Infof("resyncJob SUCCESSFULLY deleted proxy broker from platform with name [%s]", deleteRequest.Name)
+	logger.WithFields(logBroker(broker)).Infof("resyncJob successfully deleted proxy broker from platform with name [%s]", deleteRequest.Name)
 	return nil
 }
 

--- a/pkg/sbproxy/reconcile/reconcile_visibilities.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities.go
@@ -49,7 +49,7 @@ func (r *resyncJob) getPlatformVisibilitiesByBrokersFromPlatform(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("resyncJob SUCCESSFULLY retrieved %d visibilities from platform", len(visibilities))
+	logger.Infof("resyncJob successfully retrieved %d visibilities from platform", len(visibilities))
 
 	return visibilities, nil
 }
@@ -77,7 +77,7 @@ func (r *resyncJob) getSMPlansByBrokersAndOfferings(ctx context.Context, offerin
 		result[brokerID] = brokerPlans
 		count += len(brokerPlans)
 	}
-	log.C(ctx).Infof("resyncJob SUCCESSFULLY retrieved %d plans from Service Manager", count)
+	log.C(ctx).Infof("resyncJob successfully retrieved %d plans from Service Manager", count)
 
 	return result, nil
 }
@@ -93,7 +93,7 @@ func (r *resyncJob) getSMServiceOfferingsByBrokers(ctx context.Context, brokers 
 	if err != nil {
 		return nil, err
 	}
-	log.C(ctx).Infof("resyncJob SUCCESSFULLY retrieved %d service offerings from Service Manager", len(offerings))
+	log.C(ctx).Infof("resyncJob successfully retrieved %d service offerings from Service Manager", len(offerings))
 
 	for _, offering := range offerings {
 		if result[offering.BrokerID] == nil {
@@ -113,7 +113,7 @@ func (r *resyncJob) getVisibilitiesFromSM(ctx context.Context, smPlansMap map[br
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("resyncJob SUCCESSFULLY retrieved %d visibilities from Service Manager", len(visibilities))
+	logger.Infof("resyncJob successfully retrieved %d visibilities from Service Manager", len(visibilities))
 
 	result := make([]*platform.Visibility, 0)
 
@@ -131,7 +131,7 @@ func (r *resyncJob) getVisibilitiesFromSM(ctx context.Context, smPlansMap map[br
 			result = append(result, converted...)
 		}
 	}
-	logger.Infof("resyncJob SUCCESSFULLY converted %d Service Manager visibilities to %d platform visibilities", len(visibilities), len(result))
+	logger.Infof("resyncJob successfully converted %d Service Manager visibilities to %d platform visibilities", len(visibilities), len(result))
 
 	return result, nil
 }
@@ -237,7 +237,8 @@ func (r *resyncJob) getVisibilityKey(visibility *platform.Visibility) string {
 
 func (r *resyncJob) createVisibility(ctx context.Context, visibility *platform.Visibility) error {
 	logger := log.C(ctx)
-	logger.Infof("resyncJob creating visibility for catalog plan %s with labels %v...", visibility.CatalogPlanID, visibility.Labels)
+	logger.Infof("resyncJob creating visibility for catalog plan %s from broker %s ...",
+		visibility.CatalogPlanID, visibility.PlatformBrokerName)
 
 	if err := r.platformClient.Visibility().EnableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
 		BrokerName:    visibility.PlatformBrokerName,
@@ -246,14 +247,15 @@ func (r *resyncJob) createVisibility(ctx context.Context, visibility *platform.V
 	}); err != nil {
 		return err
 	}
-	logger.Infof("resyncJob SUCCESSFULLY created visibility for catalog plan %s with labels %v", visibility.CatalogPlanID, visibility.Labels)
+	logger.Infof("resyncJob successfully created visibility for catalog plan %s from broker %s",
+		visibility.CatalogPlanID, visibility.PlatformBrokerName)
 
 	return nil
 }
 
 func (r *resyncJob) deleteVisibility(ctx context.Context, visibility *platform.Visibility) error {
 	logger := log.C(ctx)
-	logger.Infof("resyncJob deleting visibility for catalog plan %s with labels %v...", visibility.CatalogPlanID, visibility.Labels)
+	logger.Infof("resyncJob deleting visibility for catalog plan %s ...", visibility.CatalogPlanID)
 
 	if err := r.platformClient.Visibility().DisableAccessForPlan(ctx, &platform.ModifyPlanAccessRequest{
 		BrokerName:    visibility.PlatformBrokerName,
@@ -262,7 +264,7 @@ func (r *resyncJob) deleteVisibility(ctx context.Context, visibility *platform.V
 	}); err != nil {
 		return err
 	}
-	logger.Infof("resyncJob SUCCESSFULLY deleted visibility for catalog plan %s with labels %v", visibility.CatalogPlanID, visibility.Labels)
+	logger.Infof("resyncJob successfully deleted visibility for catalog plan %s", visibility.CatalogPlanID)
 
 	return nil
 }

--- a/pkg/sbproxy/reconcile/reconciler.go
+++ b/pkg/sbproxy/reconcile/reconciler.go
@@ -19,9 +19,7 @@ package reconcile
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/Peripli/service-manager/pkg/types"
 
@@ -47,34 +45,6 @@ type TimestampedError struct {
 
 func (te TimestampedError) Error() string {
 	return fmt.Sprintf("%s-%s", te.Timestamp, te.Cause)
-}
-
-// CompositeError consists of multiple errors and attaches timestamps to them
-type CompositeError []error
-
-// Error implements the error interface and returns a string representation of the composite error
-func (ce *CompositeError) Error() string {
-	errs := make([]string, 0, len(*ce))
-	for i := range *ce {
-		if (*ce)[i] != nil {
-			errs = append(errs, (*ce)[i].Error())
-		}
-	}
-
-	return fmt.Sprintf("composite error: %v", strings.Join(errs, "; "))
-}
-
-// Add allows appending errors
-func (ce *CompositeError) Add(e error) {
-	*ce = append(*ce, TimestampedError{Cause: e, Timestamp: time.Now().Format(time.RFC3339Nano)})
-}
-
-// Len returns the number of errors present in the composite error. If the composite error is nil, Len returns 0.
-func (ce *CompositeError) Len() int {
-	if ce == nil {
-		return 0
-	}
-	return len(*ce)
 }
 
 // Reconciler takes care of propagating broker and visibility changes to the platform.

--- a/pkg/sbproxy/reconcile/resyncer.go
+++ b/pkg/sbproxy/reconcile/resyncer.go
@@ -89,7 +89,7 @@ func (r *resyncJob) process(ctx context.Context) {
 		logger.WithError(err).Error("an error occurred while obtaining brokers from Platform")
 		return
 	}
-	logger.Infof("resyncJob SUCCESSFULLY retrieved %d brokers from platform", len(platformBrokers))
+	logger.Infof("resyncJob successfully retrieved %d brokers from platform", len(platformBrokers))
 
 	r.reconcileBrokers(ctx, platformBrokers, smBrokers)
 	r.resetPlatformCache(ctx)

--- a/pkg/sbproxy/reconcile/task_scheduler.go
+++ b/pkg/sbproxy/reconcile/task_scheduler.go
@@ -2,14 +2,17 @@ package reconcile
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
+
+	"github.com/Peripli/service-manager/pkg/log"
 )
 
 //TaskScheduler schedules tasks to be executed in parallel
 type TaskScheduler struct {
-	ctx            context.Context
-	mutex          sync.Mutex
-	errorsCocurred *CompositeError
+	ctx        context.Context
+	errorCount uint32
 
 	waitGroupLimit chan struct{}
 	wg             sync.WaitGroup
@@ -19,7 +22,6 @@ type TaskScheduler struct {
 func NewScheduler(ctx context.Context, maxParallelTasks int) *TaskScheduler {
 	return &TaskScheduler{
 		ctx:            ctx,
-		errorsCocurred: &CompositeError{},
 		waitGroupLimit: make(chan struct{}, maxParallelTasks),
 	}
 }
@@ -39,9 +41,8 @@ func (state *TaskScheduler) Schedule(f func(context.Context) error) error {
 		}()
 
 		if err := f(state.ctx); err != nil {
-			state.mutex.Lock()
-			defer state.mutex.Unlock()
-			state.errorsCocurred.Add(err)
+			log.C(state.ctx).Error(err)
+			atomic.AddUint32(&state.errorCount, 1)
 		}
 	}()
 
@@ -51,8 +52,8 @@ func (state *TaskScheduler) Schedule(f func(context.Context) error) error {
 //Await waits for the completion of all scheduled tasks
 func (state *TaskScheduler) Await() error {
 	state.wg.Wait()
-	if state.errorsCocurred.Len() != 0 {
-		return state.errorsCocurred
+	if state.errorCount > 0 {
+		return fmt.Errorf("%d errors occurred", state.errorCount)
 	}
 
 	return nil

--- a/pkg/sbproxy/reconcile/task_scheduler.go
+++ b/pkg/sbproxy/reconcile/task_scheduler.go
@@ -11,11 +11,10 @@ import (
 
 //TaskScheduler schedules tasks to be executed in parallel
 type TaskScheduler struct {
-	ctx        context.Context
-	errorCount uint32
-
+	ctx            context.Context
 	waitGroupLimit chan struct{}
 	wg             sync.WaitGroup
+	errorCount     uint32
 }
 
 //NewScheduler return a new task scheduler configured to execute a maximum of maxParallelTasks concurrently

--- a/pkg/sbproxy/reconcile/task_scheduler_test.go
+++ b/pkg/sbproxy/reconcile/task_scheduler_test.go
@@ -1,0 +1,72 @@
+package reconcile_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Peripli/service-broker-proxy/pkg/sbproxy/reconcile"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const maxParallelTasks = 5
+
+var _ = Describe("TaskScheduler", func() {
+	It("runs at max N tasks in parallel", func() {
+		scheduler := reconcile.NewScheduler(context.Background(), maxParallelTasks)
+
+		nTasks := maxParallelTasks * 3
+		c := &counter{}
+		for i := 0; i < nTasks; i++ {
+			scheduler.Schedule(func(ctx context.Context) error {
+				c.enter()
+				defer c.leave()
+
+				time.Sleep(100 * time.Millisecond)
+				return nil
+			})
+		}
+		Expect(scheduler.Await()).To(Succeed())
+		Expect(c.maxCount).To(Equal(maxParallelTasks))
+	})
+
+	It("returns an error with the number of errors", func() {
+		scheduler := reconcile.NewScheduler(context.Background(), maxParallelTasks)
+
+		for i := 0; i < 5; i++ {
+			i := i
+			scheduler.Schedule(func(ctx context.Context) error {
+				if i%2 == 0 {
+					return fmt.Errorf("error %d", i)
+				}
+				return nil
+			})
+		}
+		Expect(scheduler.Await()).To(MatchError("3 errors occurred"))
+	})
+})
+
+type counter struct {
+	mutex    sync.Mutex
+	count    int
+	maxCount int
+}
+
+func (c *counter) enter() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.count++
+	if c.count > c.maxCount {
+		c.maxCount = c.count
+	}
+}
+
+func (c *counter) leave() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.count--
+}


### PR DESCRIPTION
Large log messages may be cropped and cause additional leg messages to be dropped.
Do not accumulate errors, but log them as they happen.
Visibility labels can be on the order of 50k - do not log the full list.