### PR TITLE
Fetch all SM offerings and plans

### DIFF
--- a/pkg/sbproxy/reconcile/reconcile_visibilities.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities.go
@@ -18,7 +18,6 @@ package reconcile
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
@@ -63,7 +62,10 @@ func (r *resyncJob) brokerNames(brokers []*platform.ServiceBroker) []string {
 	return names
 }
 
-func (r *resyncJob) getSMPlansByBrokersAndOfferings(ctx context.Context, offerings map[string]*types.ServiceOffering) (map[string][]*types.ServicePlan, error) {
+func (r *resyncJob) getSMBrokerPlans(
+	ctx context.Context, offerings map[string]*types.ServiceOffering, smBrokers []*platform.ServiceBroker) (
+	map[string]brokerPlan, error) {
+
 	log.C(ctx).Info("resyncJob getting service plans from Service Manager")
 	plans, err := r.smClient.GetPlans(ctx)
 	if err != nil {
@@ -71,20 +73,30 @@ func (r *resyncJob) getSMPlansByBrokersAndOfferings(ctx context.Context, offerin
 	}
 	log.C(ctx).Infof("resyncJob successfully retrieved %d plans from Service Manager", len(plans))
 
-	result := make(map[string][]*types.ServicePlan)
+	brokerMap := make(map[string]*platform.ServiceBroker, len(smBrokers))
+	for _, broker := range smBrokers {
+		brokerMap[broker.GUID] = broker
+	}
+
+	brokerPlans := make(map[string]brokerPlan, len(plans))
 	for _, plan := range plans {
 		service := offerings[plan.ServiceOfferingID]
 		if service == nil {
-			return nil, fmt.Errorf(
-				"inconsistent data received from Service Manager: plan with id %s references missing service id %s",
-				plan.ID, plan.ServiceOfferingID)
+			continue
 		}
-		result[service.BrokerID] = append(result[service.BrokerID], plan)
+		broker := brokerMap[service.BrokerID]
+		if broker == nil {
+			continue
+		}
+		brokerPlans[plan.ID] = brokerPlan{
+			ServicePlan: plan,
+			broker:      broker,
+		}
 	}
-	return result, nil
+	return brokerPlans, nil
 }
 
-func (r *resyncJob) getSMServiceOfferingsByBrokers(ctx context.Context, brokers []*platform.ServiceBroker) (map[string]*types.ServiceOffering, error) {
+func (r *resyncJob) getSMServiceOfferings(ctx context.Context) (map[string]*types.ServiceOffering, error) {
 	log.C(ctx).Info("resyncJob getting service offerings from Service Manager...")
 	offerings, err := r.smClient.GetServiceOfferings(ctx)
 	if err != nil {
@@ -99,7 +111,7 @@ func (r *resyncJob) getSMServiceOfferingsByBrokers(ctx context.Context, brokers 
 	return result, nil
 }
 
-func (r *resyncJob) getVisibilitiesFromSM(ctx context.Context, smPlansMap map[brokerPlanKey]*types.ServicePlan, smBrokers []*platform.ServiceBroker) ([]*platform.Visibility, error) {
+func (r *resyncJob) getVisibilitiesFromSM(ctx context.Context, smPlansMap map[string]brokerPlan) ([]*platform.Visibility, error) {
 	logger := log.C(ctx)
 	logger.Info("resyncJob getting visibilities from Service Manager...")
 
@@ -112,25 +124,19 @@ func (r *resyncJob) getVisibilitiesFromSM(ctx context.Context, smPlansMap map[br
 	result := make([]*platform.Visibility, 0)
 
 	for _, visibility := range visibilities {
-		for _, broker := range smBrokers {
-			key := brokerPlanKey{
-				brokerID: broker.GUID,
-				planID:   visibility.ServicePlanID,
-			}
-			smPlan, found := smPlansMap[key]
-			if !found {
-				continue
-			}
-			converted := r.convertSMVisibility(visibility, smPlan, broker)
-			result = append(result, converted...)
+		smPlan, found := smPlansMap[visibility.ServicePlanID]
+		if !found {
+			continue
 		}
+		converted := r.convertSMVisibility(visibility, smPlan)
+		result = append(result, converted...)
 	}
 	logger.Infof("resyncJob successfully converted %d Service Manager visibilities to %d platform visibilities", len(visibilities), len(result))
 
 	return result, nil
 }
 
-func (r *resyncJob) convertSMVisibility(visibility *types.Visibility, smPlan *types.ServicePlan, broker *platform.ServiceBroker) []*platform.Visibility {
+func (r *resyncJob) convertSMVisibility(visibility *types.Visibility, smPlan brokerPlan) []*platform.Visibility {
 	scopeLabelKey := r.platformClient.Visibility().VisibilityScopeLabelKey()
 	shouldBePublic := visibility.PlatformID == "" || len(visibility.Labels[scopeLabelKey]) == 0
 
@@ -139,7 +145,7 @@ func (r *resyncJob) convertSMVisibility(visibility *types.Visibility, smPlan *ty
 			{
 				Public:             true,
 				CatalogPlanID:      smPlan.CatalogID,
-				PlatformBrokerName: r.brokerProxyName(broker),
+				PlatformBrokerName: r.brokerProxyName(smPlan.broker),
 				Labels:             map[string]string{},
 			},
 		}
@@ -151,7 +157,7 @@ func (r *resyncJob) convertSMVisibility(visibility *types.Visibility, smPlan *ty
 		result = append(result, &platform.Visibility{
 			Public:             false,
 			CatalogPlanID:      smPlan.CatalogID,
-			PlatformBrokerName: r.brokerProxyName(broker),
+			PlatformBrokerName: r.brokerProxyName(smPlan.broker),
 			Labels:             map[string]string{scopeLabelKey: scope},
 		})
 	}
@@ -272,25 +278,6 @@ func (r *resyncJob) convertVisListToMap(list []*platform.Visibility) map[string]
 	return result
 }
 
-func mapPlansByBrokerPlanID(plansByBroker map[string][]*types.ServicePlan) map[brokerPlanKey]*types.ServicePlan {
-	plansMap := make(map[brokerPlanKey]*types.ServicePlan, len(plansByBroker))
-	for brokerID, brokerPlans := range plansByBroker {
-		for _, plan := range brokerPlans {
-			key := brokerPlanKey{
-				brokerID: brokerID,
-				planID:   plan.ID,
-			}
-			plansMap[key] = plan
-		}
-	}
-	return plansMap
-}
-
-type brokerPlanKey struct {
-	brokerID string
-	planID   string
-}
-
 func mapToLabels(m map[string]string) types.Labels {
 	labels := types.Labels{}
 	for k, v := range m {
@@ -299,4 +286,9 @@ func mapToLabels(m map[string]string) types.Labels {
 		}
 	}
 	return labels
+}
+
+type brokerPlan struct {
+	*types.ServicePlan
+	broker *platform.ServiceBroker
 }

--- a/pkg/sbproxy/reconcile/reconcile_visibilities.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities.go
@@ -62,10 +62,7 @@ func (r *resyncJob) brokerNames(brokers []*platform.ServiceBroker) []string {
 	return names
 }
 
-func (r *resyncJob) getSMBrokerPlans(
-	ctx context.Context, offerings map[string]*types.ServiceOffering, smBrokers []*platform.ServiceBroker) (
-	map[string]brokerPlan, error) {
-
+func (r *resyncJob) getSMBrokerPlans(ctx context.Context, offerings map[string]*types.ServiceOffering, smBrokers []*platform.ServiceBroker) (map[string]brokerPlan, error) {
 	log.C(ctx).Info("resyncJob getting service plans from Service Manager")
 	plans, err := r.smClient.GetPlans(ctx)
 	if err != nil {

--- a/pkg/sbproxy/reconcile/reconcile_visibilities.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities.go
@@ -76,7 +76,7 @@ func (r *resyncJob) getSMPlansByBrokersAndOfferings(ctx context.Context, offerin
 		service := offerings[plan.ServiceOfferingID]
 		if service == nil {
 			return nil, fmt.Errorf(
-				"Inconsistent data received from Service Manager: plan with id %s references missing service id %s",
+				"inconsistent data received from Service Manager: plan with id %s references missing service id %s",
 				plan.ID, plan.ServiceOfferingID)
 		}
 		result[service.BrokerID] = append(result[service.BrokerID], plan)

--- a/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_visibilities_test.go
@@ -236,27 +236,19 @@ var _ = Describe("Reconcile visibilities", func() {
 		}
 
 		fakeSMClient.GetBrokersReturns(smBrokers, nil)
-		fakeSMClient.GetServiceOfferingsByBrokerIDsCalls(func(ctx context.Context, brokerIDs []string) ([]*types.ServiceOffering, error) {
+		fakeSMClient.GetServiceOfferingsCalls(func(ctx context.Context) ([]*types.ServiceOffering, error) {
 			var result []*types.ServiceOffering
-			for _, brokerID := range brokerIDs {
-				for _, broker := range smBrokers {
-					if brokerID == broker.ID {
-						result = append(result, broker.Services...)
-					}
-				}
+			for _, broker := range smBrokers {
+				result = append(result, broker.Services...)
 			}
 			return result, nil
 		})
 
-		fakeSMClient.GetPlansByServiceOfferingsCalls(func(ctx context.Context, offerings []*types.ServiceOffering) ([]*types.ServicePlan, error) {
+		fakeSMClient.GetPlansCalls(func(ctx context.Context) ([]*types.ServicePlan, error) {
 			var result []*types.ServicePlan
-			for _, serviceOffering := range offerings {
-				for _, broker := range smBrokers {
-					for _, brokerServiceOffering := range broker.Services {
-						if serviceOffering.ID == brokerServiceOffering.ID {
-							result = append(result, brokerServiceOffering.Plans...)
-						}
-					}
+			for _, broker := range smBrokers {
+				for _, brokerServiceOffering := range broker.Services {
+					result = append(result, brokerServiceOffering.Plans...)
 				}
 			}
 			return result, nil
@@ -620,9 +612,7 @@ var _ = Describe("Reconcile visibilities", func() {
 
 		Entry("When services from SM could not be fetched - should not reconcile", testCase{
 			stubs: func() {
-				fakeSMClient.GetServiceOfferingsByBrokerIDsCalls(func(ctx context.Context, brokerIDs []string) ([]*types.ServiceOffering, error) {
-					return nil, fmt.Errorf("error")
-				})
+				fakeSMClient.GetServiceOfferingsReturns(nil, fmt.Errorf("error"))
 			},
 			platformVisibilities: func() []*platform.Visibility {
 				return []*platform.Visibility{
@@ -650,9 +640,7 @@ var _ = Describe("Reconcile visibilities", func() {
 
 		Entry("When plans from SM could not be fetched - should not reconcile", testCase{
 			stubs: func() {
-				fakeSMClient.GetPlansByServiceOfferingsCalls(func(ctx context.Context, offerings []*types.ServiceOffering) ([]*types.ServicePlan, error) {
-					return nil, fmt.Errorf("error")
-				})
+				fakeSMClient.GetPlansReturns(nil, fmt.Errorf("error"))
 			},
 			platformVisibilities: func() []*platform.Visibility {
 				return []*platform.Visibility{

--- a/pkg/sbproxy/reconcile/resyncer.go
+++ b/pkg/sbproxy/reconcile/resyncer.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Peripli/service-broker-proxy/pkg/sm"
 
 	"github.com/Peripli/service-manager/pkg/log"
-	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 )
@@ -75,8 +74,7 @@ func (r *resyncJob) process(ctx context.Context) {
 		return
 	}
 
-	mappedPlans := mapPlansByBrokerPlanID(plansFromSM)
-	smVisibilities, err := r.getVisibilitiesFromSM(ctx, mappedPlans, smBrokers) // fetch as soon as possible
+	smVisibilities, err := r.getVisibilitiesFromSM(ctx, plansFromSM) // fetch as soon as possible
 	if err != nil {
 		logger.WithError(err).Error("an error occurred while obtaining visibilities from Service Manager")
 		return
@@ -96,12 +94,12 @@ func (r *resyncJob) process(ctx context.Context) {
 	r.reconcileVisibilities(ctx, smVisibilities, smBrokers)
 }
 
-func (r *resyncJob) getSMPlans(ctx context.Context, smBrokers []*platform.ServiceBroker) (map[string][]*types.ServicePlan, error) {
-	smOfferings, err := r.getSMServiceOfferingsByBrokers(ctx, smBrokers)
+func (r *resyncJob) getSMPlans(ctx context.Context, smBrokers []*platform.ServiceBroker) (map[string]brokerPlan, error) {
+	smOfferings, err := r.getSMServiceOfferings(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "an error occurred while obtaining service offerings from Service Manager")
 	}
-	smPlans, err := r.getSMPlansByBrokersAndOfferings(ctx, smOfferings)
+	smPlans, err := r.getSMBrokerPlans(ctx, smOfferings, smBrokers)
 	if err != nil {
 		return nil, errors.Wrap(err, "an error occurred while obtaining plans from Service Manager")
 	}

--- a/pkg/sm/smfakes/fake_client.go
+++ b/pkg/sm/smfakes/fake_client.go
@@ -36,31 +36,16 @@ type FakeClient struct {
 		result1 []*types.ServicePlan
 		result2 error
 	}
-	GetPlansByServiceOfferingsStub        func(context.Context, []*types.ServiceOffering) ([]*types.ServicePlan, error)
-	getPlansByServiceOfferingsMutex       sync.RWMutex
-	getPlansByServiceOfferingsArgsForCall []struct {
+	GetServiceOfferingsStub        func(context.Context) ([]*types.ServiceOffering, error)
+	getServiceOfferingsMutex       sync.RWMutex
+	getServiceOfferingsArgsForCall []struct {
 		arg1 context.Context
-		arg2 []*types.ServiceOffering
 	}
-	getPlansByServiceOfferingsReturns struct {
-		result1 []*types.ServicePlan
-		result2 error
-	}
-	getPlansByServiceOfferingsReturnsOnCall map[int]struct {
-		result1 []*types.ServicePlan
-		result2 error
-	}
-	GetServiceOfferingsByBrokerIDsStub        func(context.Context, []string) ([]*types.ServiceOffering, error)
-	getServiceOfferingsByBrokerIDsMutex       sync.RWMutex
-	getServiceOfferingsByBrokerIDsArgsForCall []struct {
-		arg1 context.Context
-		arg2 []string
-	}
-	getServiceOfferingsByBrokerIDsReturns struct {
+	getServiceOfferingsReturns struct {
 		result1 []*types.ServiceOffering
 		result2 error
 	}
-	getServiceOfferingsByBrokerIDsReturnsOnCall map[int]struct {
+	getServiceOfferingsReturnsOnCall map[int]struct {
 		result1 []*types.ServiceOffering
 		result2 error
 	}
@@ -219,139 +204,64 @@ func (fake *FakeClient) GetPlansReturnsOnCall(i int, result1 []*types.ServicePla
 	}{result1, result2}
 }
 
-func (fake *FakeClient) GetPlansByServiceOfferings(arg1 context.Context, arg2 []*types.ServiceOffering) ([]*types.ServicePlan, error) {
-	var arg2Copy []*types.ServiceOffering
-	if arg2 != nil {
-		arg2Copy = make([]*types.ServiceOffering, len(arg2))
-		copy(arg2Copy, arg2)
-	}
-	fake.getPlansByServiceOfferingsMutex.Lock()
-	ret, specificReturn := fake.getPlansByServiceOfferingsReturnsOnCall[len(fake.getPlansByServiceOfferingsArgsForCall)]
-	fake.getPlansByServiceOfferingsArgsForCall = append(fake.getPlansByServiceOfferingsArgsForCall, struct {
+func (fake *FakeClient) GetServiceOfferings(arg1 context.Context) ([]*types.ServiceOffering, error) {
+	fake.getServiceOfferingsMutex.Lock()
+	ret, specificReturn := fake.getServiceOfferingsReturnsOnCall[len(fake.getServiceOfferingsArgsForCall)]
+	fake.getServiceOfferingsArgsForCall = append(fake.getServiceOfferingsArgsForCall, struct {
 		arg1 context.Context
-		arg2 []*types.ServiceOffering
-	}{arg1, arg2Copy})
-	fake.recordInvocation("GetPlansByServiceOfferings", []interface{}{arg1, arg2Copy})
-	fake.getPlansByServiceOfferingsMutex.Unlock()
-	if fake.GetPlansByServiceOfferingsStub != nil {
-		return fake.GetPlansByServiceOfferingsStub(arg1, arg2)
+	}{arg1})
+	fake.recordInvocation("GetServiceOfferings", []interface{}{arg1})
+	fake.getServiceOfferingsMutex.Unlock()
+	if fake.GetServiceOfferingsStub != nil {
+		return fake.GetServiceOfferingsStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPlansByServiceOfferingsReturns
+	fakeReturns := fake.getServiceOfferingsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeClient) GetPlansByServiceOfferingsCallCount() int {
-	fake.getPlansByServiceOfferingsMutex.RLock()
-	defer fake.getPlansByServiceOfferingsMutex.RUnlock()
-	return len(fake.getPlansByServiceOfferingsArgsForCall)
+func (fake *FakeClient) GetServiceOfferingsCallCount() int {
+	fake.getServiceOfferingsMutex.RLock()
+	defer fake.getServiceOfferingsMutex.RUnlock()
+	return len(fake.getServiceOfferingsArgsForCall)
 }
 
-func (fake *FakeClient) GetPlansByServiceOfferingsCalls(stub func(context.Context, []*types.ServiceOffering) ([]*types.ServicePlan, error)) {
-	fake.getPlansByServiceOfferingsMutex.Lock()
-	defer fake.getPlansByServiceOfferingsMutex.Unlock()
-	fake.GetPlansByServiceOfferingsStub = stub
+func (fake *FakeClient) GetServiceOfferingsCalls(stub func(context.Context) ([]*types.ServiceOffering, error)) {
+	fake.getServiceOfferingsMutex.Lock()
+	defer fake.getServiceOfferingsMutex.Unlock()
+	fake.GetServiceOfferingsStub = stub
 }
 
-func (fake *FakeClient) GetPlansByServiceOfferingsArgsForCall(i int) (context.Context, []*types.ServiceOffering) {
-	fake.getPlansByServiceOfferingsMutex.RLock()
-	defer fake.getPlansByServiceOfferingsMutex.RUnlock()
-	argsForCall := fake.getPlansByServiceOfferingsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+func (fake *FakeClient) GetServiceOfferingsArgsForCall(i int) context.Context {
+	fake.getServiceOfferingsMutex.RLock()
+	defer fake.getServiceOfferingsMutex.RUnlock()
+	argsForCall := fake.getServiceOfferingsArgsForCall[i]
+	return argsForCall.arg1
 }
 
-func (fake *FakeClient) GetPlansByServiceOfferingsReturns(result1 []*types.ServicePlan, result2 error) {
-	fake.getPlansByServiceOfferingsMutex.Lock()
-	defer fake.getPlansByServiceOfferingsMutex.Unlock()
-	fake.GetPlansByServiceOfferingsStub = nil
-	fake.getPlansByServiceOfferingsReturns = struct {
-		result1 []*types.ServicePlan
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) GetPlansByServiceOfferingsReturnsOnCall(i int, result1 []*types.ServicePlan, result2 error) {
-	fake.getPlansByServiceOfferingsMutex.Lock()
-	defer fake.getPlansByServiceOfferingsMutex.Unlock()
-	fake.GetPlansByServiceOfferingsStub = nil
-	if fake.getPlansByServiceOfferingsReturnsOnCall == nil {
-		fake.getPlansByServiceOfferingsReturnsOnCall = make(map[int]struct {
-			result1 []*types.ServicePlan
-			result2 error
-		})
-	}
-	fake.getPlansByServiceOfferingsReturnsOnCall[i] = struct {
-		result1 []*types.ServicePlan
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) GetServiceOfferingsByBrokerIDs(arg1 context.Context, arg2 []string) ([]*types.ServiceOffering, error) {
-	var arg2Copy []string
-	if arg2 != nil {
-		arg2Copy = make([]string, len(arg2))
-		copy(arg2Copy, arg2)
-	}
-	fake.getServiceOfferingsByBrokerIDsMutex.Lock()
-	ret, specificReturn := fake.getServiceOfferingsByBrokerIDsReturnsOnCall[len(fake.getServiceOfferingsByBrokerIDsArgsForCall)]
-	fake.getServiceOfferingsByBrokerIDsArgsForCall = append(fake.getServiceOfferingsByBrokerIDsArgsForCall, struct {
-		arg1 context.Context
-		arg2 []string
-	}{arg1, arg2Copy})
-	fake.recordInvocation("GetServiceOfferingsByBrokerIDs", []interface{}{arg1, arg2Copy})
-	fake.getServiceOfferingsByBrokerIDsMutex.Unlock()
-	if fake.GetServiceOfferingsByBrokerIDsStub != nil {
-		return fake.GetServiceOfferingsByBrokerIDsStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.getServiceOfferingsByBrokerIDsReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeClient) GetServiceOfferingsByBrokerIDsCallCount() int {
-	fake.getServiceOfferingsByBrokerIDsMutex.RLock()
-	defer fake.getServiceOfferingsByBrokerIDsMutex.RUnlock()
-	return len(fake.getServiceOfferingsByBrokerIDsArgsForCall)
-}
-
-func (fake *FakeClient) GetServiceOfferingsByBrokerIDsCalls(stub func(context.Context, []string) ([]*types.ServiceOffering, error)) {
-	fake.getServiceOfferingsByBrokerIDsMutex.Lock()
-	defer fake.getServiceOfferingsByBrokerIDsMutex.Unlock()
-	fake.GetServiceOfferingsByBrokerIDsStub = stub
-}
-
-func (fake *FakeClient) GetServiceOfferingsByBrokerIDsArgsForCall(i int) (context.Context, []string) {
-	fake.getServiceOfferingsByBrokerIDsMutex.RLock()
-	defer fake.getServiceOfferingsByBrokerIDsMutex.RUnlock()
-	argsForCall := fake.getServiceOfferingsByBrokerIDsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeClient) GetServiceOfferingsByBrokerIDsReturns(result1 []*types.ServiceOffering, result2 error) {
-	fake.getServiceOfferingsByBrokerIDsMutex.Lock()
-	defer fake.getServiceOfferingsByBrokerIDsMutex.Unlock()
-	fake.GetServiceOfferingsByBrokerIDsStub = nil
-	fake.getServiceOfferingsByBrokerIDsReturns = struct {
+func (fake *FakeClient) GetServiceOfferingsReturns(result1 []*types.ServiceOffering, result2 error) {
+	fake.getServiceOfferingsMutex.Lock()
+	defer fake.getServiceOfferingsMutex.Unlock()
+	fake.GetServiceOfferingsStub = nil
+	fake.getServiceOfferingsReturns = struct {
 		result1 []*types.ServiceOffering
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeClient) GetServiceOfferingsByBrokerIDsReturnsOnCall(i int, result1 []*types.ServiceOffering, result2 error) {
-	fake.getServiceOfferingsByBrokerIDsMutex.Lock()
-	defer fake.getServiceOfferingsByBrokerIDsMutex.Unlock()
-	fake.GetServiceOfferingsByBrokerIDsStub = nil
-	if fake.getServiceOfferingsByBrokerIDsReturnsOnCall == nil {
-		fake.getServiceOfferingsByBrokerIDsReturnsOnCall = make(map[int]struct {
+func (fake *FakeClient) GetServiceOfferingsReturnsOnCall(i int, result1 []*types.ServiceOffering, result2 error) {
+	fake.getServiceOfferingsMutex.Lock()
+	defer fake.getServiceOfferingsMutex.Unlock()
+	fake.GetServiceOfferingsStub = nil
+	if fake.getServiceOfferingsReturnsOnCall == nil {
+		fake.getServiceOfferingsReturnsOnCall = make(map[int]struct {
 			result1 []*types.ServiceOffering
 			result2 error
 		})
 	}
-	fake.getServiceOfferingsByBrokerIDsReturnsOnCall[i] = struct {
+	fake.getServiceOfferingsReturnsOnCall[i] = struct {
 		result1 []*types.ServiceOffering
 		result2 error
 	}{result1, result2}
@@ -488,10 +398,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.getBrokersMutex.RUnlock()
 	fake.getPlansMutex.RLock()
 	defer fake.getPlansMutex.RUnlock()
-	fake.getPlansByServiceOfferingsMutex.RLock()
-	defer fake.getPlansByServiceOfferingsMutex.RUnlock()
-	fake.getServiceOfferingsByBrokerIDsMutex.RLock()
-	defer fake.getServiceOfferingsByBrokerIDsMutex.RUnlock()
+	fake.getServiceOfferingsMutex.RLock()
+	defer fake.getServiceOfferingsMutex.RUnlock()
 	fake.getVisibilitiesMutex.RLock()
 	defer fake.getVisibilitiesMutex.RUnlock()
 	fake.putCredentialsMutex.RLock()


### PR DESCRIPTION
Fetch all service offerings from SM. Previously we used to filter them by broker id, but sometimes this made the URL too long > 9000 chars
Fetch all service plans from SM in a single call to improve performance.

Less is more 😋