### PR TITLE
Add SM broker ID to platform client requests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -322,7 +322,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e8501d7fa801be523f103178ced935b37778925c7338f0f94e50c14a4d450f4a"
+  digest = "1:00a8bb2a5d9b736e4f8c5f3f3bc0b73aeb0ef1b91e63f72f322750370a3b3757"
   name = "github.com/lib/pq"
   packages = [
     ".",
@@ -330,7 +330,7 @@
     "scram",
   ]
   pruneopts = "UT"
-  revision = "9eb3fc897d6fd97dd4aad3d0404b54e2f7cc56be"
+  revision = "356e267cd3f45ee1303b7d8765e3583cb949950e"
 
 [[projects]]
   digest = "1:5a0ef768465592efca0412f7e838cdc0826712f8447e70e6ccc52eb441e9ab13"
@@ -415,12 +415,12 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:6eea828983c70075ca297bb915ffbcfd3e34c5a50affd94428a65df955c0ff9c"
+  digest = "1:1d835d5c3153aceef96c2d58866edde1aa70e25339831cff07b1e47456410e5c"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   pruneopts = "UT"
-  revision = "903d9455db9ff1d7ac1ab199062eca7266dd11a3"
-  version = "v1.6.0"
+  revision = "8e8d2a6aad23fcaa64716c5fa6975ec3abbf8281"
+  version = "v1.7.0"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
@@ -544,12 +544,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:b70c951ba6fdeecfbd50dabe95aa5e1b973866ae9abbece46ad60348112214f2"
+  digest = "1:d6144d834c1d542969d499093cb6df7e0dbaebfb510bdda5648fd35ea4aee7c3"
   name = "github.com/tidwall/sjson"
   packages = ["."]
   pruneopts = "UT"
-  revision = "25fb082a20e29e83fb7b7ef5f5919166aad1f084"
-  version = "v1.0.4"
+  revision = "11cb24d8421de3e1bb5c5efb066a03037150568d"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:c468422f334a6b46a19448ad59aaffdfc0a36b08fdcc1c749a0b29b6453d7e59"
@@ -634,7 +634,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "0ec3e9974c59449edd84298612e9f16fa13368e8"
+  revision = "baeed622b8d86045ff442b324772b0ad306a2b3f"
 
 [[projects]]
   branch = "master"
@@ -665,11 +665,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8b163cc073aac41680c1ce438eae6b046f04511952e60c3cff2915033fe6f58b"
+  digest = "1:842f1500cf319662226ee2f897aa1bf5e9228bb851af8a9aaef5c425fe90f14e"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "85ca7c5b95cdf1e557abb38a283d1e61a5959c31"
+  revision = "c3d80250170dec19bf61949c81233cede5ddaf61"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"

--- a/pkg/platform/broker_client.go
+++ b/pkg/platform/broker_client.go
@@ -22,6 +22,7 @@ import (
 
 // CreateServiceBrokerRequest type used for requests by the platform client
 type CreateServiceBrokerRequest struct {
+	ID        string `json:"id"`
 	Name      string `json:"name"`
 	BrokerURL string `json:"broker_url"`
 	Username  string `json:"username"`
@@ -30,6 +31,7 @@ type CreateServiceBrokerRequest struct {
 
 // UpdateServiceBrokerRequest type used for requests by the platform client
 type UpdateServiceBrokerRequest struct {
+	ID        string `json:"id"`
 	GUID      string `json:"guid"`
 	Name      string `json:"name"`
 	BrokerURL string `json:"broker_url"`
@@ -39,6 +41,7 @@ type UpdateServiceBrokerRequest struct {
 
 // DeleteServiceBrokerRequest type used for requests by the platform client
 type DeleteServiceBrokerRequest struct {
+	ID   string `json:"id"`
 	GUID string `json:"guid"`
 	Name string `json:"name"`
 }

--- a/pkg/sbproxy/notifications/handlers/broker_handler.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler.go
@@ -133,6 +133,7 @@ func (bnh *BrokerResourceNotificationsHandler) OnCreate(ctx context.Context, not
 		}
 
 		createRequest := &platform.CreateServiceBrokerRequest{
+			ID:        brokerToCreate.Resource.GetID(),
 			Name:      brokerProxyName,
 			BrokerURL: brokerProxyPath,
 			Username:  username,
@@ -159,6 +160,7 @@ func (bnh *BrokerResourceNotificationsHandler) OnCreate(ctx context.Context, not
 			}
 
 			updateRequest := &platform.UpdateServiceBrokerRequest{
+				ID:        brokerToCreate.Resource.ID,
 				GUID:      existingBroker.GUID,
 				Name:      brokerProxyName,
 				BrokerURL: brokerProxyPath,
@@ -233,6 +235,7 @@ func (bnh *BrokerResourceNotificationsHandler) OnUpdate(ctx context.Context, not
 	}
 
 	updateRequest := &platform.UpdateServiceBrokerRequest{
+		ID:        brokerAfterUpdate.Resource.ID,
 		GUID:      existingBroker.GUID,
 		Name:      brokerProxyNameAfter,
 		BrokerURL: brokerProxyPath,
@@ -318,6 +321,7 @@ func (bnh *BrokerResourceNotificationsHandler) OnDelete(ctx context.Context, not
 	log.C(ctx).Infof("Successfully found platform broker with name %s and URL %s. Attempting to delete...", existingBroker.Name, existingBroker.BrokerURL)
 
 	deleteRequest := &platform.DeleteServiceBrokerRequest{
+		ID:   brokerToDelete.Resource.ID,
 		GUID: existingBroker.GUID,
 		Name: brokerProxyName,
 	}

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -274,7 +274,7 @@ var _ = Describe("Broker Handler", func() {
 				}, nil)
 
 				expectedUpdateBrokerRequest = &platform.UpdateServiceBrokerRequest{
-					ID: smBrokerID,
+					ID:        smBrokerID,
 					GUID:      smBrokerID,
 					Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 					BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
@@ -344,7 +344,7 @@ var _ = Describe("Broker Handler", func() {
 					fakeBrokerClient.GetBrokerByNameReturns(nil, nil)
 
 					expectedCreateBrokerRequest = &platform.CreateServiceBrokerRequest{
-						ID: smBrokerID,
+						ID:        smBrokerID,
 						Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 						BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
 					}
@@ -599,7 +599,7 @@ var _ = Describe("Broker Handler", func() {
 				}
 				brokerHandler.OnUpdate(ctx, brokerNotification)
 				expectedReq := &platform.UpdateServiceBrokerRequest{
-					ID: smBrokerID,
+					ID:        smBrokerID,
 					GUID:      smBrokerID,
 					Name:      brokerProxyName(brokerHandler.ProxyPrefix, newBrokerName, smBrokerID),
 					BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -784,6 +784,7 @@ var _ = Describe("Broker Handler", func() {
 
 				BeforeEach(func() {
 					expectedDeleteBrokerRequest = &platform.DeleteServiceBrokerRequest{
+						ID:   smBrokerID,
 						GUID: smBrokerID,
 						Name: brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 					}

--- a/pkg/sbproxy/notifications/handlers/broker_handler_test.go
+++ b/pkg/sbproxy/notifications/handlers/broker_handler_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Broker Handler", func() {
 	var catalog string
 
 	assertCreateBrokerRequest := func(actualReq, expectedReq *platform.CreateServiceBrokerRequest) {
+		Expect(actualReq.ID).To(Equal(expectedReq.ID))
 		Expect(actualReq.Name).To(Equal(expectedReq.Name))
 		Expect(actualReq.BrokerURL).To(Equal(expectedReq.BrokerURL))
 		Expect(actualReq.Username).ToNot(BeEmpty())
@@ -46,6 +47,7 @@ var _ = Describe("Broker Handler", func() {
 	}
 
 	assertUpdateBrokerRequest := func(actualReq, expectedReq *platform.UpdateServiceBrokerRequest) {
+		Expect(actualReq.ID).To(Equal(expectedReq.ID))
 		Expect(actualReq.GUID).To(Equal(expectedReq.GUID))
 		Expect(actualReq.Name).To(Equal(expectedReq.Name))
 		Expect(actualReq.BrokerURL).To(Equal(expectedReq.BrokerURL))
@@ -272,6 +274,7 @@ var _ = Describe("Broker Handler", func() {
 				}, nil)
 
 				expectedUpdateBrokerRequest = &platform.UpdateServiceBrokerRequest{
+					ID: smBrokerID,
 					GUID:      smBrokerID,
 					Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 					BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
@@ -341,6 +344,7 @@ var _ = Describe("Broker Handler", func() {
 					fakeBrokerClient.GetBrokerByNameReturns(nil, nil)
 
 					expectedCreateBrokerRequest = &platform.CreateServiceBrokerRequest{
+						ID: smBrokerID,
 						Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 						BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
 					}
@@ -595,6 +599,7 @@ var _ = Describe("Broker Handler", func() {
 				}
 				brokerHandler.OnUpdate(ctx, brokerNotification)
 				expectedReq := &platform.UpdateServiceBrokerRequest{
+					ID: smBrokerID,
 					GUID:      smBrokerID,
 					Name:      brokerProxyName(brokerHandler.ProxyPrefix, newBrokerName, smBrokerID),
 					BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,
@@ -631,6 +636,7 @@ var _ = Describe("Broker Handler", func() {
 
 				BeforeEach(func() {
 					expectedUpdateBrokerRequest = &platform.UpdateServiceBrokerRequest{
+						ID:        smBrokerID,
 						GUID:      smBrokerID,
 						Name:      brokerProxyName(brokerHandler.ProxyPrefix, brokerName, smBrokerID),
 						BrokerURL: brokerHandler.SMPath + "/" + smBrokerID,

--- a/pkg/sbproxy/reconcile/reconcile_brokers.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers.go
@@ -164,6 +164,7 @@ func (r *resyncJob) fetchBrokerCatalog(ctx context.Context, brokerGUIDInPlatform
 		}
 
 		updateRequest := &platform.UpdateServiceBrokerRequest{
+			ID:        brokerInSM.GUID,
 			GUID:      brokerGUIDInPlatform,
 			Name:      r.brokerProxyName(brokerInSM),
 			BrokerURL: r.smPath + "/" + brokerInSM.GUID,
@@ -198,6 +199,7 @@ func (r *resyncJob) createBrokerRegistration(ctx context.Context, brokerInSM *pl
 	}
 
 	createRequest := &platform.CreateServiceBrokerRequest{
+		ID:        brokerInSM.GUID,
 		Name:      r.brokerProxyName(brokerInSM),
 		BrokerURL: r.smPath + "/" + brokerInSM.GUID,
 		Username:  username,
@@ -235,6 +237,7 @@ func (r *resyncJob) updateBrokerRegistration(ctx context.Context, brokerGUIDInPl
 	}
 
 	updateRequest := &platform.UpdateServiceBrokerRequest{
+		ID:        brokerInSM.GUID,
 		GUID:      brokerGUIDInPlatform,
 		Name:      r.brokerProxyName(brokerInSM),
 		BrokerURL: r.smPath + "/" + brokerInSM.GUID,
@@ -255,6 +258,7 @@ func (r *resyncJob) deleteBrokerRegistration(ctx context.Context, broker *platfo
 	logger.WithFields(logBroker(broker)).Info("resyncJob deleting broker from platform...")
 
 	deleteRequest := &platform.DeleteServiceBrokerRequest{
+		ID:   brokerIDFromURL(broker.BrokerURL),
 		GUID: broker.GUID,
 		Name: broker.Name,
 	}

--- a/pkg/sbproxy/reconcile/reconcile_brokers_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_brokers_test.go
@@ -855,6 +855,7 @@ var _ = Describe("Reconcile brokers", func() {
 		}
 		for _, broker := range expected.reconcileCreateCalledFor {
 			Expect(calledCreateBrokerRequests).To(ContainElement(&platform.CreateServiceBrokerRequest{
+				ID:        brokerIDFromURL(broker.BrokerURL),
 				Name:      broker.Name,
 				BrokerURL: broker.BrokerURL,
 			}))
@@ -874,6 +875,7 @@ var _ = Describe("Reconcile brokers", func() {
 		}
 		for _, broker := range expected.reconcileCatalogCalledFor {
 			Expect(calledFetchCatalogBrokers).To(ContainElement(&platform.UpdateServiceBrokerRequest{
+				ID:        brokerIDFromURL(broker.BrokerURL),
 				GUID:      broker.GUID,
 				Name:      broker.Name,
 				BrokerURL: broker.BrokerURL,
@@ -888,6 +890,7 @@ var _ = Describe("Reconcile brokers", func() {
 		}
 		for _, broker := range expected.reconcileDeleteCalledFor {
 			Expect(calledDeleteBrokerRequests).To(ContainElement(&platform.DeleteServiceBrokerRequest{
+				ID:   brokerIDFromURL(broker.BrokerURL),
 				GUID: broker.GUID,
 				Name: broker.Name,
 			}))
@@ -907,6 +910,7 @@ var _ = Describe("Reconcile brokers", func() {
 		}
 		for _, broker := range expected.reconcileUpdateCalledFor {
 			Expect(calledUpdateBrokerRequests).To(ContainElement(&platform.UpdateServiceBrokerRequest{
+				ID:        brokerIDFromURL(broker.BrokerURL),
 				GUID:      broker.GUID,
 				Name:      broker.Name,
 				BrokerURL: broker.BrokerURL,

--- a/pkg/sbproxy/reconcile/reconcile_suite_test.go
+++ b/pkg/sbproxy/reconcile/reconcile_suite_test.go
@@ -19,6 +19,7 @@ package reconcile_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Peripli/service-manager/pkg/log"
@@ -44,6 +45,10 @@ func TestReconcile(t *testing.T) {
 
 func brokerProxyName(brokerName, brokerID string) string {
 	return fmt.Sprintf("%s%s-%s", reconcile.DefaultProxyBrokerPrefix, brokerName, brokerID)
+}
+
+func brokerIDFromURL(brokerURL string) string {
+	return brokerURL[strings.LastIndex(brokerURL, "/")+1:]
 }
 
 func verifyInvocationsUseSameCorrelationID(invocations []map[string][][]interface{}) {


### PR DESCRIPTION
### Motivation

We need the SM broker ID in the platform request so we can delete K8S secrets with broker platform credentials. The secrets are named with the broker ID from SM because of the DNS name constraint by K8S.