### PR TITLE
Configure page size when fetching visibilities from SM

### DIFF
--- a/pkg/sm/client.go
+++ b/pkg/sm/client.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"time"
 
@@ -198,5 +197,5 @@ func (c *ServiceManagerClient) listAll(ctx context.Context, smURL string, params
 }
 
 func (c *ServiceManagerClient) getURL(route string) string {
-	return path.Join(c.url, route)
+	return c.url + route
 }

--- a/pkg/sm/options.go
+++ b/pkg/sm/options.go
@@ -25,6 +25,20 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Settings type holds SM Client config properties
+type Settings struct {
+	User                 string
+	Password             string
+	URL                  string
+	OSBAPIPath           string        `mapstructure:"osb_api_path"`
+	NotificationsAPIPath string        `mapstructure:"notifications_api_path"`
+	RequestTimeout       time.Duration `mapstructure:"request_timeout"`
+	SkipSSLValidation    bool          `mapstructure:"skip_ssl_validation"`
+	VisibilitiesPageSize int           `mapstructure:"visibilities_page_size"`
+
+	Transport http.RoundTripper
+}
+
 // DefaultSettings builds a default Service Manager Settings
 func DefaultSettings() *Settings {
 	return &Settings{
@@ -50,19 +64,6 @@ func NewSettings(env env.Environment) (*Settings, error) {
 	}
 
 	return config.Sm, nil
-}
-
-// Settings type holds SM Client config properties
-type Settings struct {
-	User                 string
-	Password             string
-	URL                  string
-	OSBAPIPath           string        `mapstructure:"osb_api_path"`
-	NotificationsAPIPath string        `mapstructure:"notifications_api_path"`
-	RequestTimeout       time.Duration `mapstructure:"request_timeout"`
-	SkipSSLValidation    bool          `mapstructure:"skip_ssl_validation"`
-
-	Transport http.RoundTripper
 }
 
 // Validate validates the configuration and returns appropriate errors in case it is invalid


### PR DESCRIPTION
Visibilities may grow very large due to labels. Due to this, fetching all of them in one request may timeout.
Now it is possible to configure a smaller page size when fetching visibilities from SM.
The env var is `SM_VISIBILITIES_PAGE_SIZE`.
If not set, the server default page size is used.