### PR TITLE
Adding mTLS connectivity support for service broker proxy

### DIFF
--- a/pkg/sbproxy/notifications/producer.go
+++ b/pkg/sbproxy/notifications/producer.go
@@ -286,6 +286,11 @@ func (p *Producer) connect(ctx context.Context) error {
 	headers := http.Header{}
 	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(p.smSettings.User+":"+p.smSettings.Password))
 	headers.Add("Authorization", auth)
+	tlsCertificates, err := p.smSettings.GetCertificates()
+
+	if err != nil {
+		return err
+	}
 
 	connectURL := *p.url
 	if p.lastNotificationRevision != types.InvalidRevision {
@@ -298,11 +303,11 @@ func (p *Producer) connect(ctx context.Context) error {
 		HandshakeTimeout: p.smSettings.RequestTimeout,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: p.smSettings.SkipSSLValidation,
+			Certificates:       tlsCertificates,
 		},
 	}
 
 	log.C(ctx).Debugf("Connecting to %s ...", &connectURL)
-	var err error
 	var resp *http.Response
 	p.conn, resp, err = dialer.DialContext(ctx, connectURL.String(), headers)
 	if err != nil {

--- a/pkg/sbproxy/notifications/producer_test.go
+++ b/pkg/sbproxy/notifications/producer_test.go
@@ -2,6 +2,8 @@ package notifications_test
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +27,100 @@ import (
 )
 
 var invalidRevisionStr = strconv.FormatInt(types.InvalidRevision, 10)
+var (
+	ClientCertificate = `-----BEGIN CERTIFICATE-----
+MIICrjCCAZYCCQDfb7elrdbtvDANBgkqhkiG9w0BAQUFADAYMRYwFAYDVQQDDA1G
+aXJzdCBNLiBMYXN0MCAXDTIwMDMyNDE5NTE0MloYDzMwMDAwNTI2MTk1MTQyWjAY
+MRYwFAYDVQQDDA1GaXJzdCBNLiBMYXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAyJ3Hr9hJits2ssZZu4ZaZrKxDWHffYPRQNDlNJg8uldXtizjxiyo
+0bS+LmiejmyIPRa7BE38ctqoFKPcqJoHy63imWr5plJDbHpacdi1s9FhSsLFCJPe
+QK4+GSDu1pOWiqWETomRVz+q0NbYaURT3qZ/YW3cCrRns/+CITz+J3bWHcVBARaq
+A+WS/K3dtknTb4On0AeD4SVT5UI19alF3xooh7HG4cp+5j8JtX8CazIrdjFfEUW2
+k17a3FiQbyRPYFa52of+59kFd08ABPHwmSeRdUzyhYgn+fYUZ9qUJ9twwgDi50mJ
+LDyyp+bGg3exrSy1QQE4rqXuQuPvBBKOiQIDAQABMA0GCSqGSIb3DQEBBQUAA4IB
+AQDCiBUdE4chHdUYK2FPrkk72GQiEXTDUP4OZpkJ6mLNCj25j/UC4ND8ByfnsYbx
+4rF1Q4JslZZg80NXDSJMR43kfAt+7hnKoYHceCD2FsSlMxP+aOiaa7FbKUSqYnU1
++GGdK13EygiMr1RkVhG8GRngUvE5YzDwcm1jl4pOsShHaX26pititxwKCJSABA3G
+1nfrfyHb9N30cN0Z6u4eYpMidO5Txs8Fl0Jh/xJOperl/3Z2ubWKPd1eelhS8GXx
+ox8VI+BTty9Yl0fRl12cRsSF1ddOKBJxcdp3Ae2AZZ762vm/ESr1TzrX+wYgLUxp
+1I6ycxMDnvvDWmGO0V4HDkPR
+-----END CERTIFICATE-----`
+
+	ClientKey = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDIncev2EmK2zay
+xlm7hlpmsrENYd99g9FA0OU0mDy6V1e2LOPGLKjRtL4uaJ6ObIg9FrsETfxy2qgU
+o9yomgfLreKZavmmUkNselpx2LWz0WFKwsUIk95Arj4ZIO7Wk5aKpYROiZFXP6rQ
+1thpRFPepn9hbdwKtGez/4IhPP4ndtYdxUEBFqoD5ZL8rd22SdNvg6fQB4PhJVPl
+QjX1qUXfGiiHscbhyn7mPwm1fwJrMit2MV8RRbaTXtrcWJBvJE9gVrnah/7n2QV3
+TwAE8fCZJ5F1TPKFiCf59hRn2pQn23DCAOLnSYksPLKn5saDd7GtLLVBATiupe5C
+4+8EEo6JAgMBAAECggEAJtFo1xyptkWOgu8gY8mualq/KZC7luTPs5P4FcIzVfca
+kLSE6k6v58vqVL6Hl5VmkzN3wnB4nZyzkzLVuoX7ZiziQL9TSRx30WCnaYn+NqoY
+AkhHqc463hcZCvG1ZS2vnmpCfJPf3JsEKV65Bz1iYR2kXizMvAGGY2zYOCg+IVJk
+IJg7TcbrdgA03/IqE2FoPHXuAlAhm5312o+N1h4wXnWRrzUDR9FMOiQCKAUtMuIU
+iHMJ7naQjwjJKKsOeDeF1bzgSR4WmZZk5w8fCDdgHFpSn86DZBSfOu6t7kzhOvwR
+pu6dxl1t7FPXWtu2jr+/WP0ZtoP2XeKdUMdSlZZSgQKBgQD6Kc5M4TIgjpAOrYMH
+1GSD8ccr9KJIX+qy7iDNpzEb38g1Uvsx2OvYLkT1vDhmerRYbai3v+ZU2LBIASzy
+gNvbeIRarvEmdoMB7iSTw4D0JJdm+JSf5n3BpBZ+b3IqGNQeBJAmoEv2aCvQOZNe
+J+t0FfmgRZDj3paUIZFgTjfj8QKBgQDNTAlJPFUows0Hyd4FWlNhqalLyQWVtVzB
+swJPdkyW1hPzZGHnuhDGv2azsraQy2vZUjo8p/zn4mytWng0ya7SzXZlbbdvIU/o
+QMraQGIkQDADMwg95Y5R6h0FCxsBBmHaI4YpFtvk+ZvDELv927aXpzgyCj4v/lSc
+qSw2ts4MGQKBgG6vcqUXertm+JxV70TWl8a9gleTfP4y2kBjFkaH9DWWFRpq5dPP
+W8Kh7kcgCYBmSEdb9aufj8T4vz6Mrpt5ok2ADGenQfG3vA1tled/OB5N1mNsFy6M
+qBW2iXFV1BiGNcw2TqWYhSO4QbJ21xpw5T/OvU1JmmsIQG24UH9g/F+xAoGAPtq1
+yR9Yr1cc8PKEMD1cY/1O4O4V8KULVh6ZaXy9rDy09QLZ2tmjw0Xcis3/iUtOpMXB
+IMsJ6nDvdw/I19ib1tyjECDMVZDsZx5XPQUTRygDyyb3sgOzVC8KXX3t8Z1jnibc
+L35ZKrylTM61z95SBBJlaSSrr4P9oc1FxSao5RkCgYBhAh11SGmBntpW02ky8SbW
+WUKaIE168cJ4xJmzwAV1OmZbMlc4AhJ9xmkbaViIpIe4Z/R0jp+ZbaFgsgtySER/
+ZcJLWYGz00zKINL3Z9FKTa0Opg30AC9kZi9YbJMlsSJMoXx6mTE4kcYHOKv4f1qQ
+XL31L67QikBXJnPmtkwxSQ==
+-----END PRIVATE KEY-----`
+
+	InvalidClientCertificate = `-----BEGIN CERTIFICATE-----
+MIICrDCCAZQCCQCpKp1xS5g91TANBgkqhkiG9w0BAQUFADAYMRYwFAYDVQQDDA1G
+aXJzdCBNLiBMYXN0MB4XDTIwMDMyNTE2MjQzNFoXDTIwMDQyNDE2MjQzNFowGDEW
+MBQGA1UEAwwNRmlyc3QgTS4gTGFzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAMX+zkYBETE0RtBlbE6OBesnTYDNYA345vGkpVlcJEZwFEr5mMFZ5z2s
+dUQuUwLJIStDvxphrUCof99vPr925Ladcq/W9Gl4DkG7NP76AXeykJYC+7mvoZJH
+fOSRM6TOA/OkdYk5ZGmQzflSvO33Xyj+MmZ/9uQtkz+ZCOyHxcwPxFFinPNl5fZv
+LiN0p+zIvIFScpiAm1/YziaFX7XdJXlhBxMeqUWdDQuGCYGiRYdU7oZB7t2gA2Wa
+oXjiOWpkd0ka4/EM/rPPWudwlbIMHd2e+ddwc7XFtN5wBhdo3bB8s3Dc9B8S3Xv1
+e+1a/Iq7sQ//5eMh3s69/Sghi5Avu9kCAwEAATANBgkqhkiG9w0BAQUFAAOCAQEA
+br2agn+j98e2KANkEM99Xk/oBsSmyp2tkwYr7p4dJUTCa8auLJbjIsdX9vsyprUd
+JvoUamO8TKSGMhkjTS6MZJpILqJMWTpBXmDb0lktwJd062QLZklhttvhLv9YJuEG
+/VXWgyRrQ4Jpy2+QAc8sWhtF42Vyu7sJZuikyT8FWO3fsILpdIg/SjsO2UGsP8hE
+e6sqXUtHY6HXCdwRA4STY3ICZVMjw+NkfJPpC3gL7xbZHzzlwxQXqo7ySal4e6Sl
+5ruwMNVt+2KVXdshqGNbRYNGs0x96iWbi8zRFx3uuIwLIDghWQqv+8gKcxttvkjP
+LjRFM2n5hd6MzWG9criQfA==
+-----END CERTIFICATE-----`
+	InvalidClientKey = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDF/s5GARExNEbQ
+ZWxOjgXrJ02AzWAN+ObxpKVZXCRGcBRK+ZjBWec9rHVELlMCySErQ78aYa1AqH/f
+bz6/duS2nXKv1vRpeA5BuzT++gF3spCWAvu5r6GSR3zkkTOkzgPzpHWJOWRpkM35
+Urzt918o/jJmf/bkLZM/mQjsh8XMD8RRYpzzZeX2by4jdKfsyLyBUnKYgJtf2M4m
+hV+13SV5YQcTHqlFnQ0LhgmBokWHVO6GQe7doANlmqF44jlqZHdJGuPxDP6zz1rn
+cJWyDB3dnvnXcHO1xbTecAYXaN2wfLNw3PQfEt179XvtWvyKu7EP/+XjId7Ovf0o
+IYuQL7vZAgMBAAECggEBAKomTx3ZzOx8AF8Wyfy4EF4FaJVH6UQYol8HHxGsHYBq
+0QWdeaivmglmK2Bsbun17os/rPr+9eSa6UkaUNI5WlOU+vohv+jjQ105hFGah6hV
+y+sepTTtuev7g1jpb3gxkzPOITPMHn6Z8mhQsgvOifiwep+bWJC+mcwNt52NEG5L
+m1jBbDvGDQL3oiSIzMnFd58WZm5lQpTIapcx+lvKtVSn2xb/d0BigCTonZXMUZhL
+2y5kcGJSvNaYgrjc0oZDA3gZ4YdoUrMW99CFFeECbbzASp01J+ivIn/Tke1VCHoe
+AI4GJFiSFA5jiALkxB1KMIgzaSlg1sGS5VDrlSLu8AECgYEA5qrEtgqTFOuM+Ot7
+1QCva5rei8QN8qBczmSB1pZEWtmJNopU1soLOrDdj3sw0l1Up2hSBGiEwcbiTrr+
+if3YUZkRRFv5D7BGnQLhe4QcXaANPjsExeQ1NOgaruIVRzaVv4PXhMP0VPErNehl
+NKuhVdOI971rbSdG3A2xrELOtqMCgYEA2713xS0/3hepmlO0PHAWsQZjle9zBLPM
+SvWqcArrVPRdam4x5yNOnonkGghJ/4G4xWXLHxTNJqshzuGHH9iq8Hk2mQfxMmFO
+8l4sTz4d8D6GECGodKov3gDZ6h0BBBR9qv+b5Z3H7jZ2+MD5h9y17g/Kx1NXBnF1
+NQNg3Oi0t1MCgYAJayelF0FyNTwIXfUseV6wUh6MLnEzWwDvHIOAs5oO65sCsxtL
+uexDdT1Wwnz32f++5i+TJoFlOC29cT07fTX7/vgJhofg8B2yA5AZbweJeyOPSvGi
+8vKJOoD8axbbVYs/yq5eKXIslbxh8x9Oy0NHMeAB3aYpStVF3vlGQ2QVaQKBgQDS
+eP9ggL/9BaMxK92mSiKh+yGl+o2rwl/6qKZQ3VSdsdZMXDI2V241kpRGjwv5zRHj
+GWZeZfk+gYpHc2OPEGRjI2c1WxMfE2+f3K4KVNAuTmTwzJxi6qQgu6X+hTt04f+g
+q2ZyoBdhRw/bolMgXDpyRPQQyfXAOSpv1cWQsuBt+wKBgAmGjk+97Y+7eFiHQqKd
+AB3SPFZoHO6s7UKDU2Uv7u3NAfQ+/FydwgtfDEcD9aISVZ9DVZJy4/kOSUIc45rG
++XjDdXNcJIN2fNiPMaAimisjxPC83UxrirAJISnHrJwqaCfUwDSArz+Lvf+WlZCL
+AxcGuEEhttwyFSfydmYdBaQx
+-----END PRIVATE KEY-----`
+)
 
 func TestNotifications(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -219,7 +315,90 @@ var _ = Describe("Notifications", func() {
 			})
 		})
 
-		Context("When websocket is connected", func() {
+		Context("When a server that accept mTLS exists", func() {
+			var tlsServer *httptest.Server
+			var tlsSocketServer *wsServer
+
+			BeforeEach(func() {
+				tlsServer, tlsSocketServer = newServerWithTLS()
+				producerSettings = &notifications.ProducerSettings{
+					MinPingPeriod:        100 * time.Millisecond,
+					ReconnectDelay:       100 * time.Millisecond,
+					PongTimeout:          20 * time.Millisecond,
+					ResyncPeriod:         300 * time.Millisecond,
+					PingPeriodPercentage: 60,
+					MessagesQueueSize:    10,
+				}
+
+				smSettings = &sm.Settings{
+					URL:                  tlsServer.URL,
+					User:                 "admin",
+					Password:             "admin",
+					RequestTimeout:       11 * time.Second,
+					TLSClientCertificate: ClientCertificate,
+					TLSClientKey:         ClientKey,
+					SkipSSLValidation:    true,
+					NotificationsAPIPath: "/v1/notifications",
+				}
+			})
+
+			AfterEach(func() {
+				tlsServer.Close()
+			})
+
+			When("valid mTLS certificate and private keys are used", func() {
+				BeforeEach(func() {
+					smSettings.TLSClientCertificate = ClientCertificate
+					smSettings.TLSClientKey = ClientKey
+				})
+
+				It("should successfully establish a socket connection", func() {
+					times := make(chan time.Time, 1)
+					tlsSocketServer.onClientConnected = func(conn *websocket.Conn) {
+						times <- time.Now()
+					}
+					newProducer, _ := notifications.NewProducer(producerSettings, smSettings)
+					newProducer.Start(producerCtx, group)
+					Eventually(times, time.Millisecond*100).Should(Receive())
+				})
+			})
+
+			When("an invalid certificate is used with a valid client key", func() {
+				BeforeEach(func() {
+					smSettings.TLSClientCertificate = InvalidClientKey
+					smSettings.TLSClientKey = ClientKey
+				})
+
+				It("should not establish a socket connection", func() {
+					times := make(chan time.Time, 1)
+					tlsSocketServer.onClientConnected = func(conn *websocket.Conn) {
+						times <- time.Now()
+					}
+					newProducer, _ := notifications.NewProducer(producerSettings, smSettings)
+					newProducer.Start(producerCtx, group)
+					Consistently(times, time.Millisecond*100).ShouldNot(Receive())
+				})
+			})
+
+			When("when both certificate and client key are invalid", func() {
+				BeforeEach(func() {
+					smSettings.TLSClientCertificate = InvalidClientCertificate
+					smSettings.TLSClientKey = InvalidClientKey
+				})
+
+				It("should not establish a socket connection", func() {
+					times := make(chan time.Time, 1)
+					tlsSocketServer.onClientConnected = func(conn *websocket.Conn) {
+						times <- time.Now()
+					}
+					newProducer, _ := notifications.NewProducer(producerSettings, smSettings)
+					newProducer.Start(producerCtx, group)
+					Consistently(times, time.Millisecond*100).ShouldNot(Receive())
+				})
+			})
+		})
+
+		Context("When a websocket is connected", func() {
 			It("Pings the servers within max_ping_period", func(done Done) {
 				times := make(chan time.Time, 10)
 				server.onClientConnected = func(conn *websocket.Conn) {
@@ -479,6 +658,25 @@ func newWSServer() *wsServer {
 	mux.HandleFunc("/v1/notifications", s.handler)
 	s.mux = mux
 	return s
+}
+
+func newServerWithTLS() (*httptest.Server, *wsServer) {
+	s := &wsServer{
+		maxPingPeriod:            (100 * time.Millisecond).String(),
+		lastNotificationRevision: strconv.FormatInt(types.InvalidRevision, 10),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/notifications", s.handler)
+
+	uServer := httptest.NewUnstartedServer(mux)
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM([]byte(ClientCertificate))
+	uServer.TLS = &tls.Config{}
+	uServer.TLS.ClientCAs = caCertPool
+	uServer.TLS.ClientAuth = tls.RequireAndVerifyClientCert
+	uServer.StartTLS()
+	return uServer, s
 }
 
 func (s *wsServer) Start() {

--- a/pkg/sm/client.go
+++ b/pkg/sm/client.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -62,12 +61,18 @@ func NewClient(config *Settings) (*ServiceManagerClient, error) {
 	}
 
 	httpClient := &http.Client{}
-	httpClient.Timeout = time.Duration(config.RequestTimeout)
+	httpClient.Timeout = config.RequestTimeout
+	tlsCerts, err := config.GetCertificates()
+	if err != nil {
+		return nil, err
+	}
+
 	tr := config.Transport
 
 	if tr == nil {
-		tr = &SkipSSLTransport{
+		tr = &SSLTransport{
 			SkipSslValidation: config.SkipSSLValidation,
+			TLSCertificates:   tlsCerts,
 		}
 	}
 

--- a/pkg/sm/client_test.go
+++ b/pkg/sm/client_test.go
@@ -18,10 +18,15 @@ package sm
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/gorilla/mux"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"path"
 	"strconv"
 	"time"
@@ -43,6 +48,120 @@ const smURL = "http://example.com"
 
 type MockTransport struct {
 	f func(req *http.Request) (*http.Response, error)
+}
+
+//Test certificates
+var (
+	InvalidClientCertificate = `-----BEGIN CERTIFICATE-----
+MIICrDCCAZQCCQCpKp1xS5g91TANBgkqhkiG9w0BAQUFADAYMRYwFAYDVQQDDA1G
+aXJzdCBNLiBMYXN0MB4XDTIwMDMyNTE2MjQzNFoXDTIwMDQyNDE2MjQzNFowGDEW
+MBQGA1UEAwwNRmlyc3QgTS4gTGFzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAMX+zkYBETE0RtBlbE6OBesnTYDNYA345vGkpVlcJEZwFEr5mMFZ5z2s
+dUQuUwLJIStDvxphrUCof99vPr925Ladcq/W9Gl4DkG7NP76AXeykJYC+7mvoZJH
+fOSRM6TOA/OkdYk5ZGmQzflSvO33Xyj+MmZ/9uQtkz+ZCOyHxcwPxFFinPNl5fZv
+LiN0p+zIvIFScpiAm1/YziaFX7XdJXlhBxMeqUWdDQuGCYGiRYdU7oZB7t2gA2Wa
+oXjiOWpkd0ka4/EM/rPPWudwlbIMHd2e+ddwc7XFtN5wBhdo3bB8s3Dc9B8S3Xv1
+e+1a/Iq7sQ//5eMh3s69/Sghi5Avu9kCAwEAATANBgkqhkiG9w0BAQUFAAOCAQEA
+br2agn+j98e2KANkEM99Xk/oBsSmyp2tkwYr7p4dJUTCa8auLJbjIsdX9vsyprUd
+JvoUamO8TKSGMhkjTS6MZJpILqJMWTpBXmDb0lktwJd062QLZklhttvhLv9YJuEG
+/VXWgyRrQ4Jpy2+QAc8sWhtF42Vyu7sJZuikyT8FWO3fsILpdIg/SjsO2UGsP8hE
+e6sqXUtHY6HXCdwRA4STY3ICZVMjw+NkfJPpC3gL7xbZHzzlwxQXqo7ySal4e6Sl
+5ruwMNVt+2KVXdshqGNbRYNGs0x96iWbi8zRFx3uuIwLIDghWQqv+8gKcxttvkjP
+LjRFM2n5hd6MzWG9criQfA==
+-----END CERTIFICATE-----`
+	InvalidClientKey = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDF/s5GARExNEbQ
+ZWxOjgXrJ02AzWAN+ObxpKVZXCRGcBRK+ZjBWec9rHVELlMCySErQ78aYa1AqH/f
+bz6/duS2nXKv1vRpeA5BuzT++gF3spCWAvu5r6GSR3zkkTOkzgPzpHWJOWRpkM35
+Urzt918o/jJmf/bkLZM/mQjsh8XMD8RRYpzzZeX2by4jdKfsyLyBUnKYgJtf2M4m
+hV+13SV5YQcTHqlFnQ0LhgmBokWHVO6GQe7doANlmqF44jlqZHdJGuPxDP6zz1rn
+cJWyDB3dnvnXcHO1xbTecAYXaN2wfLNw3PQfEt179XvtWvyKu7EP/+XjId7Ovf0o
+IYuQL7vZAgMBAAECggEBAKomTx3ZzOx8AF8Wyfy4EF4FaJVH6UQYol8HHxGsHYBq
+0QWdeaivmglmK2Bsbun17os/rPr+9eSa6UkaUNI5WlOU+vohv+jjQ105hFGah6hV
+y+sepTTtuev7g1jpb3gxkzPOITPMHn6Z8mhQsgvOifiwep+bWJC+mcwNt52NEG5L
+m1jBbDvGDQL3oiSIzMnFd58WZm5lQpTIapcx+lvKtVSn2xb/d0BigCTonZXMUZhL
+2y5kcGJSvNaYgrjc0oZDA3gZ4YdoUrMW99CFFeECbbzASp01J+ivIn/Tke1VCHoe
+AI4GJFiSFA5jiALkxB1KMIgzaSlg1sGS5VDrlSLu8AECgYEA5qrEtgqTFOuM+Ot7
+1QCva5rei8QN8qBczmSB1pZEWtmJNopU1soLOrDdj3sw0l1Up2hSBGiEwcbiTrr+
+if3YUZkRRFv5D7BGnQLhe4QcXaANPjsExeQ1NOgaruIVRzaVv4PXhMP0VPErNehl
+NKuhVdOI971rbSdG3A2xrELOtqMCgYEA2713xS0/3hepmlO0PHAWsQZjle9zBLPM
+SvWqcArrVPRdam4x5yNOnonkGghJ/4G4xWXLHxTNJqshzuGHH9iq8Hk2mQfxMmFO
+8l4sTz4d8D6GECGodKov3gDZ6h0BBBR9qv+b5Z3H7jZ2+MD5h9y17g/Kx1NXBnF1
+NQNg3Oi0t1MCgYAJayelF0FyNTwIXfUseV6wUh6MLnEzWwDvHIOAs5oO65sCsxtL
+uexDdT1Wwnz32f++5i+TJoFlOC29cT07fTX7/vgJhofg8B2yA5AZbweJeyOPSvGi
+8vKJOoD8axbbVYs/yq5eKXIslbxh8x9Oy0NHMeAB3aYpStVF3vlGQ2QVaQKBgQDS
+eP9ggL/9BaMxK92mSiKh+yGl+o2rwl/6qKZQ3VSdsdZMXDI2V241kpRGjwv5zRHj
+GWZeZfk+gYpHc2OPEGRjI2c1WxMfE2+f3K4KVNAuTmTwzJxi6qQgu6X+hTt04f+g
+q2ZyoBdhRw/bolMgXDpyRPQQyfXAOSpv1cWQsuBt+wKBgAmGjk+97Y+7eFiHQqKd
+AB3SPFZoHO6s7UKDU2Uv7u3NAfQ+/FydwgtfDEcD9aISVZ9DVZJy4/kOSUIc45rG
++XjDdXNcJIN2fNiPMaAimisjxPC83UxrirAJISnHrJwqaCfUwDSArz+Lvf+WlZCL
+AxcGuEEhttwyFSfydmYdBaQx
+-----END PRIVATE KEY-----`
+
+	ClientCertificate = `-----BEGIN CERTIFICATE-----
+MIICrjCCAZYCCQDfb7elrdbtvDANBgkqhkiG9w0BAQUFADAYMRYwFAYDVQQDDA1G
+aXJzdCBNLiBMYXN0MCAXDTIwMDMyNDE5NTE0MloYDzMwMDAwNTI2MTk1MTQyWjAY
+MRYwFAYDVQQDDA1GaXJzdCBNLiBMYXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAyJ3Hr9hJits2ssZZu4ZaZrKxDWHffYPRQNDlNJg8uldXtizjxiyo
+0bS+LmiejmyIPRa7BE38ctqoFKPcqJoHy63imWr5plJDbHpacdi1s9FhSsLFCJPe
+QK4+GSDu1pOWiqWETomRVz+q0NbYaURT3qZ/YW3cCrRns/+CITz+J3bWHcVBARaq
+A+WS/K3dtknTb4On0AeD4SVT5UI19alF3xooh7HG4cp+5j8JtX8CazIrdjFfEUW2
+k17a3FiQbyRPYFa52of+59kFd08ABPHwmSeRdUzyhYgn+fYUZ9qUJ9twwgDi50mJ
+LDyyp+bGg3exrSy1QQE4rqXuQuPvBBKOiQIDAQABMA0GCSqGSIb3DQEBBQUAA4IB
+AQDCiBUdE4chHdUYK2FPrkk72GQiEXTDUP4OZpkJ6mLNCj25j/UC4ND8ByfnsYbx
+4rF1Q4JslZZg80NXDSJMR43kfAt+7hnKoYHceCD2FsSlMxP+aOiaa7FbKUSqYnU1
++GGdK13EygiMr1RkVhG8GRngUvE5YzDwcm1jl4pOsShHaX26pititxwKCJSABA3G
+1nfrfyHb9N30cN0Z6u4eYpMidO5Txs8Fl0Jh/xJOperl/3Z2ubWKPd1eelhS8GXx
+ox8VI+BTty9Yl0fRl12cRsSF1ddOKBJxcdp3Ae2AZZ762vm/ESr1TzrX+wYgLUxp
+1I6ycxMDnvvDWmGO0V4HDkPR
+-----END CERTIFICATE-----`
+
+	ClientKey = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDIncev2EmK2zay
+xlm7hlpmsrENYd99g9FA0OU0mDy6V1e2LOPGLKjRtL4uaJ6ObIg9FrsETfxy2qgU
+o9yomgfLreKZavmmUkNselpx2LWz0WFKwsUIk95Arj4ZIO7Wk5aKpYROiZFXP6rQ
+1thpRFPepn9hbdwKtGez/4IhPP4ndtYdxUEBFqoD5ZL8rd22SdNvg6fQB4PhJVPl
+QjX1qUXfGiiHscbhyn7mPwm1fwJrMit2MV8RRbaTXtrcWJBvJE9gVrnah/7n2QV3
+TwAE8fCZJ5F1TPKFiCf59hRn2pQn23DCAOLnSYksPLKn5saDd7GtLLVBATiupe5C
+4+8EEo6JAgMBAAECggEAJtFo1xyptkWOgu8gY8mualq/KZC7luTPs5P4FcIzVfca
+kLSE6k6v58vqVL6Hl5VmkzN3wnB4nZyzkzLVuoX7ZiziQL9TSRx30WCnaYn+NqoY
+AkhHqc463hcZCvG1ZS2vnmpCfJPf3JsEKV65Bz1iYR2kXizMvAGGY2zYOCg+IVJk
+IJg7TcbrdgA03/IqE2FoPHXuAlAhm5312o+N1h4wXnWRrzUDR9FMOiQCKAUtMuIU
+iHMJ7naQjwjJKKsOeDeF1bzgSR4WmZZk5w8fCDdgHFpSn86DZBSfOu6t7kzhOvwR
+pu6dxl1t7FPXWtu2jr+/WP0ZtoP2XeKdUMdSlZZSgQKBgQD6Kc5M4TIgjpAOrYMH
+1GSD8ccr9KJIX+qy7iDNpzEb38g1Uvsx2OvYLkT1vDhmerRYbai3v+ZU2LBIASzy
+gNvbeIRarvEmdoMB7iSTw4D0JJdm+JSf5n3BpBZ+b3IqGNQeBJAmoEv2aCvQOZNe
+J+t0FfmgRZDj3paUIZFgTjfj8QKBgQDNTAlJPFUows0Hyd4FWlNhqalLyQWVtVzB
+swJPdkyW1hPzZGHnuhDGv2azsraQy2vZUjo8p/zn4mytWng0ya7SzXZlbbdvIU/o
+QMraQGIkQDADMwg95Y5R6h0FCxsBBmHaI4YpFtvk+ZvDELv927aXpzgyCj4v/lSc
+qSw2ts4MGQKBgG6vcqUXertm+JxV70TWl8a9gleTfP4y2kBjFkaH9DWWFRpq5dPP
+W8Kh7kcgCYBmSEdb9aufj8T4vz6Mrpt5ok2ADGenQfG3vA1tled/OB5N1mNsFy6M
+qBW2iXFV1BiGNcw2TqWYhSO4QbJ21xpw5T/OvU1JmmsIQG24UH9g/F+xAoGAPtq1
+yR9Yr1cc8PKEMD1cY/1O4O4V8KULVh6ZaXy9rDy09QLZ2tmjw0Xcis3/iUtOpMXB
+IMsJ6nDvdw/I19ib1tyjECDMVZDsZx5XPQUTRygDyyb3sgOzVC8KXX3t8Z1jnibc
+L35ZKrylTM61z95SBBJlaSSrr4P9oc1FxSao5RkCgYBhAh11SGmBntpW02ky8SbW
+WUKaIE168cJ4xJmzwAV1OmZbMlc4AhJ9xmkbaViIpIe4Z/R0jp+ZbaFgsgtySER/
+ZcJLWYGz00zKINL3Z9FKTa0Opg30AC9kZi9YbJMlsSJMoXx6mTE4kcYHOKv4f1qQ
+XL31L67QikBXJnPmtkwxSQ==
+-----END PRIVATE KEY-----`
+)
+
+func TLSMockServer(mockResponse string) *httptest.Server {
+
+	router := mux.NewRouter()
+	router.HandleFunc("/v1/testTLS", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		io.WriteString(rw, mockResponse)
+	}).Methods(http.MethodGet)
+
+	uServer := httptest.NewUnstartedServer(router)
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM([]byte(ClientCertificate))
+	uServer.TLS = &tls.Config{}
+	uServer.TLS.ClientCAs = caCertPool
+	uServer.TLS.ClientAuth = tls.RequireAndVerifyClientCert
+	uServer.StartTLS()
+	return uServer
 }
 
 func (t *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -77,6 +196,86 @@ var _ = Describe("Client", func() {
 			}
 		})
 
+		When("client is connecting to an mTLS server", func() {
+			var mockServer *httptest.Server
+			BeforeEach(func() {
+				mockServer = TLSMockServer(`{
+					"num_items": 1,
+					"items" : [{"name" : "hello world"}]
+				}`)
+
+				settings = &Settings{
+					User:                 "admin",
+					Password:             "admin",
+					URL:                  "http://example.com",
+					OSBAPIPath:           "/osb",
+					NotificationsAPIPath: "/v1/notifications",
+					RequestTimeout:       5 * time.Second,
+					SkipSSLValidation:    true,
+					TLSClientKey:         InvalidClientKey,
+					TLSClientCertificate: ClientCertificate,
+				}
+			})
+
+			AfterEach(func() {
+				mockServer.Close()
+			})
+
+			When("mTLS valid settings are present in config", func() {
+
+				BeforeEach(func() {
+					settings.TLSClientKey = ClientKey
+					settings.TLSClientCertificate = ClientCertificate
+				})
+
+				It("should establish a valid connection to the mTLS server", func() {
+					client, err := NewClient(settings)
+					Expect(err).ShouldNot(HaveOccurred())
+					transport := client.httpClient.Transport.(*BasicAuthTransport)
+					_, ok := transport.Rt.(*SSLTransport)
+					Expect(ok).To(BeTrue())
+					var params map[string]string
+					result := make([]*types.ServiceOffering, 0)
+					err = client.listAll(context.TODO(), mockServer.URL+"/v1/testTLS", params, &result)
+					Expect(result[0].Name).To(Equal("hello world"))
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+			})
+
+			When("mTLS private key does not match pubic key", func() {
+
+				BeforeEach(func() {
+					settings.TLSClientKey = ClientKey
+					settings.TLSClientCertificate = InvalidClientCertificate
+				})
+
+				It("should fail due to not matching keys", func() {
+					_, err := NewClient(settings)
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("private key does not match public key"))
+				})
+			})
+			When("bad certificates is used by the client", func() {
+				BeforeEach(func() {
+					settings.TLSClientCertificate = InvalidClientCertificate
+					settings.TLSClientKey = InvalidClientKey
+				})
+
+				It("should fail to establish a connection", func() {
+					client, err := NewClient(settings)
+					Expect(err).ShouldNot(HaveOccurred())
+					transport := client.httpClient.Transport.(*BasicAuthTransport)
+					_, ok := transport.Rt.(*SSLTransport)
+					Expect(ok).To(BeTrue())
+					var params map[string]string
+					result := make([]*types.ServiceOffering, 0)
+					err = client.listAll(context.TODO(), mockServer.URL+"/v1/testTLS", params, &result)
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("bad certificate"))
+				})
+			})
+		})
+
 		Context("when config is invalid", func() {
 			It("returns an error", func() {
 				settings.User = ""
@@ -103,7 +302,7 @@ var _ = Describe("Client", func() {
 					client, err := NewClient(settings)
 					Expect(err).ShouldNot(HaveOccurred())
 					transport := client.httpClient.Transport.(*BasicAuthTransport)
-					_, ok := transport.Rt.(*SkipSSLTransport)
+					_, ok := transport.Rt.(*SSLTransport)
 					Expect(ok).To(BeTrue())
 				})
 			})

--- a/pkg/sm/transport.go
+++ b/pkg/sm/transport.go
@@ -42,17 +42,17 @@ func (b *BasicAuthTransport) RoundTrip(request *http.Request) (*http.Response, e
 	return b.Rt.RoundTrip(request)
 }
 
-// SkipSSLTransport implements http.RoundTripper and sets the SSL Validation to match the provided property
-type SkipSSLTransport struct {
+// SSLTransport implements http.RoundTripper and sets the SSL transport
+type SSLTransport struct {
 	SkipSslValidation bool
-
-	Rt http.RoundTripper
+	TLSCertificates   []tls.Certificate
+	Rt                http.RoundTripper
 }
 
-var _ http.RoundTripper = &SkipSSLTransport{}
+var _ http.RoundTripper = &SSLTransport{}
 
 // RoundTrip implements http.RoundTrip and adds skip SSL validation logic
-func (b *SkipSSLTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+func (b *SSLTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	if b.Rt == nil {
 		b.Rt = http.DefaultTransport
 	}
@@ -60,6 +60,7 @@ func (b *SkipSSLTransport) RoundTrip(request *http.Request) (*http.Response, err
 	if defaultTransport, ok := b.Rt.(*http.Transport); ok {
 		defaultTransport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: b.SkipSslValidation,
+			Certificates:       b.TLSCertificates,
 		}
 	}
 

--- a/pkg/sm/transport_test.go
+++ b/pkg/sm/transport_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Transport", func() {
 			basicTransport = &BasicAuthTransport{
 				Username: "admin",
 				Password: "admin",
-				Rt: &SkipSSLTransport{
+				Rt: &SSLTransport{
 					SkipSslValidation: true,
 				},
 			}


### PR DESCRIPTION
This allows service broker clients to establish mTLS connectivity with a service manager (protected by mTLS)

New configuration options allows to set a tls_client_id & tls_client_certificate via the enivemrnet variables
```
TLSClientKey         string        `mapstructure:"tls_client_id"`
TLSClientCertificate string        `mapstructure:"tls_client_certificate"`
```

Having the above variables defined in the cf-proxy or k8s-proxy application env enables mTLS connectivity.

**Changes:** 

- Adding Notification over mTLS support
- Adding sm client mTLS connectivity support
- Adding support for new settings: TLSClientKey,TLSClientCertificate
- Adding TLSClientCertificate & key validations in case set


***Tests***
- Added tests that validate notification and sm-client connectivity over mTLS