### PR TITLE
fix-makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ clean-coverage:
 
 clean-vendor:
 	rm -rf vendor
-	@echo > go.mod
+	@echo > go.sum


### PR DESCRIPTION
Motivation
bug fix->cleanup should be on go.sum instead of go.mod